### PR TITLE
Improved readability of DRIVE_WHEEL_TYPE enum

### DIFF
--- a/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
@@ -631,15 +631,16 @@ public class SwerveModuleSimulation {
   }
 
   public enum DRIVE_WHEEL_TYPE {
-    RUBBER,
-    TIRE
-  }
+    RUBBER(1.25),
+    TIRE(1.15);
+    private final double grip;
+    private DRIVE_WHEEL_TYPE(double grip){
+      this.grip = grip;
+    }
 
-  private static double getWheelGripping(DRIVE_WHEEL_TYPE type) {
-    return switch (type) {
-      case RUBBER -> 1.25;
-      case TIRE -> 1.15;
-    };
+    public double getGrip(){
+      return this.grip;
+    }
   }
 
   /**
@@ -669,7 +670,7 @@ public class SwerveModuleSimulation {
             12.8,
             0.2,
             0.3,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(2),
             0.03);
   }
@@ -701,7 +702,7 @@ public class SwerveModuleSimulation {
             150.0 / 7.0,
             0.2,
             1,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(2),
             0.025);
   }
@@ -731,7 +732,7 @@ public class SwerveModuleSimulation {
             18.75,
             0.25,
             1,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(2),
             0.025);
   }
@@ -771,7 +772,7 @@ public class SwerveModuleSimulation {
             11.3142,
             0.2,
             0.3,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(2),
             0.03);
   }
@@ -811,7 +812,7 @@ public class SwerveModuleSimulation {
             11.3714,
             0.2,
             0.3,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(2),
             0.03);
   }
@@ -847,7 +848,7 @@ public class SwerveModuleSimulation {
             41.25,
             0.2,
             0.3,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(1.5),
             0.03);
   }
@@ -891,7 +892,7 @@ public class SwerveModuleSimulation {
             12.1,
             0.2,
             0.3,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(2),
             0.03);
   }
@@ -931,7 +932,7 @@ public class SwerveModuleSimulation {
             25.9,
             0.2,
             0.3,
-            getWheelGripping(driveWheelType),
+            driveWheelType.getGrip(),
             Units.inchesToMeters(1.875),
             0.03);
   }

--- a/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
@@ -630,16 +630,13 @@ public class SwerveModuleSimulation {
         / robotMass;
   }
 
-  public enum DRIVE_WHEEL_TYPE {
-    RUBBER(1.25),
-    TIRE(1.15);
-    private final double grip;
-    private DRIVE_WHEEL_TYPE(double grip){
-      this.grip = grip;
-    }
+  public enum WHEEL_GRIP {
+    RUBBER_WHEEL_GRIP(1.25),
+    TIRE_WHEEL_GRIP(1.15);
 
-    public double getGrip(){
-      return this.grip;
+    public final double grip;
+    WHEEL_GRIP(double grip){
+      this.grip = grip;
     }
   }
 
@@ -652,7 +649,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -670,7 +667,7 @@ public class SwerveModuleSimulation {
             12.8,
             0.2,
             0.3,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(2),
             0.03);
   }
@@ -684,7 +681,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -702,7 +699,7 @@ public class SwerveModuleSimulation {
             150.0 / 7.0,
             0.2,
             1,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(2),
             0.025);
   }
@@ -715,7 +712,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -732,7 +729,7 @@ public class SwerveModuleSimulation {
             18.75,
             0.25,
             1,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(2),
             0.025);
   }
@@ -749,7 +746,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -772,7 +769,7 @@ public class SwerveModuleSimulation {
             11.3142,
             0.2,
             0.3,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(2),
             0.03);
   }
@@ -789,7 +786,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -812,7 +809,7 @@ public class SwerveModuleSimulation {
             11.3714,
             0.2,
             0.3,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(2),
             0.03);
   }
@@ -828,7 +825,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -848,7 +845,7 @@ public class SwerveModuleSimulation {
             41.25,
             0.2,
             0.3,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(1.5),
             0.03);
   }
@@ -866,7 +863,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -892,7 +889,7 @@ public class SwerveModuleSimulation {
             12.1,
             0.2,
             0.3,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(2),
             0.03);
   }
@@ -909,7 +906,7 @@ public class SwerveModuleSimulation {
       DCMotor driveMotor,
       DCMotor steerMotor,
       double driveCurrentLimitAmps,
-      DRIVE_WHEEL_TYPE driveWheelType,
+      WHEEL_GRIP driveWheelType,
       int gearRatioLevel) {
     return () ->
         new SwerveModuleSimulation(
@@ -932,7 +929,7 @@ public class SwerveModuleSimulation {
             25.9,
             0.2,
             0.3,
-            driveWheelType.getGrip(),
+            driveWheelType.grip,
             Units.inchesToMeters(1.875),
             0.03);
   }


### PR DESCRIPTION
# Improved readability of DRIVE_WHEEL_TYPE enum


I changed the DRIVE_WHEEL_TYPE enum so that it uses a field for the wheel grip instead of a switch case. This should make it easier to read as all of the information is contained within the enum, and should it easier and safer to add more wheel types.