### PR TITLE
Added utility methods + naming scheme changes

### DIFF
--- a/docs/2_USING_THE_SIMULATED_ARENA.md
+++ b/docs/2_USING_THE_SIMULATED_ARENA.md
@@ -58,8 +58,12 @@ Your robot can interact with these pieces by bumping into them or grabbing them 
 To add or clear game pieces from the field:
 
 ```java
-// Add a Crescendo note to the field
-SimulatedArena.getInstance().addGamePiece(new CrescendoNoteOnField(new Translation2d(3, 3)));
+// Add a Crescendo note and a custom object to the field
+GamePieceOnField note = new CrescendoNoteOnField(new Translation2d(3, 3));
+SimulatedArena.getInstance().addGamePiece(note);
+
+// Removes the game pieces from the field
+SimulatedArena.getInstance().removeGamePiece(note);
 
 // Clear all game pieces from the field
 SimulatedArena.getInstance().clearGamePieces();
@@ -77,7 +81,7 @@ You can retrieve the positions of game pieces, including those on the ground and
 
 ```java
 // Get the positions of the notes (both on the field and in the air)
-List<Pose3d> notesPoses = SimulatedArena.getInstance().getGamePiecesByType("Note");
+Pose3d[] notesPoses = SimulatedArena.getInstance().getNotePoses();
 
 // Publish to telemetry using AdvantageKit
 Logger.recordOutput("FieldSimulation/NotesPositions", notesPoses);

--- a/docs/6_SIMULATING_OPPONENT_ROBOTS.md
+++ b/docs/6_SIMULATING_OPPONENT_ROBOTS.md
@@ -1,22 +1,6 @@
 ## Simulating Opponent Robots
 
-#### This document is based on the [AIRobotInSimulation class](https://github.com/Shenzhen-Robotics-Alliance/Maple-Swerve-Skeleton/blob/main/src/main/java/frc/robot/utils/AIRobotInSimulation.java) from Maple-Swerve-Skeleton.  Check the source for a more detailed understanding.
-
-> ⚠️ **Note**
->
-> You are reading the documentation for a Beta version of maple-sim. API references are subject to change in future versions.
-
-### 0. Overview
-Opponent robots can be added to the field for realistic driver practicing.  They can be programmed to do the following:
-
-- Automatically cycle acrross the field.  This can help the driver practice offense skills when there are other robots on field.
-- Automatically running feed-cycles to deliver feed-shot notes.  This can help the driver practice front-field clean up and feeder strategy.
-- Controlled by another joystick to play defense.  This can help the drivers practice defense and counter-defense skills.
-
-### 1. Creating and managing opponent robots
-
-Opponent robots are also simulated using the `SimplifiedSwerveDriveSimulation` class.  We need to create a container class that manages the instances.
-
+#### Comming Soon
 
 
 <div style="display:flex">

--- a/docs/javadocs/constant-values.html
+++ b/docs/javadocs/constant-values.html
@@ -81,19 +81,19 @@ loadScripts(document, 'script');</script>
 <div class="table-header col-first">Modifier and Type</div>
 <div class="table-header col-second">Constant Field</div>
 <div class="table-header col-last">Value</div>
-<div class="col-first even-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.ANGULAR_DAMPING">public&nbsp;static&nbsp;final&nbsp;double</code></div>
+<div class="col-first even-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnField.ANGULAR_DAMPING">public&nbsp;static&nbsp;final&nbsp;double</code></div>
 <div class="col-second even-row-color"><code><a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html#ANGULAR_DAMPING">ANGULAR_DAMPING</a></code></div>
 <div class="col-last even-row-color"><code>5.0</code></div>
-<div class="col-first odd-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.COEFFICIENT_OF_FRICTION">public&nbsp;static&nbsp;final&nbsp;double</code></div>
+<div class="col-first odd-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnField.COEFFICIENT_OF_FRICTION">public&nbsp;static&nbsp;final&nbsp;double</code></div>
 <div class="col-second odd-row-color"><code><a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html#COEFFICIENT_OF_FRICTION">COEFFICIENT_OF_FRICTION</a></code></div>
 <div class="col-last odd-row-color"><code>0.8</code></div>
-<div class="col-first even-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.COEFFICIENT_OF_RESTITUTION">public&nbsp;static&nbsp;final&nbsp;double</code></div>
+<div class="col-first even-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnField.COEFFICIENT_OF_RESTITUTION">public&nbsp;static&nbsp;final&nbsp;double</code></div>
 <div class="col-second even-row-color"><code><a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html#COEFFICIENT_OF_RESTITUTION">COEFFICIENT_OF_RESTITUTION</a></code></div>
 <div class="col-last even-row-color"><code>0.3</code></div>
-<div class="col-first odd-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.LINEAR_DAMPING">public&nbsp;static&nbsp;final&nbsp;double</code></div>
+<div class="col-first odd-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnField.LINEAR_DAMPING">public&nbsp;static&nbsp;final&nbsp;double</code></div>
 <div class="col-second odd-row-color"><code><a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html#LINEAR_DAMPING">LINEAR_DAMPING</a></code></div>
 <div class="col-last odd-row-color"><code>3.5</code></div>
-<div class="col-first even-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.MINIMUM_BOUNCING_VELOCITY">public&nbsp;static&nbsp;final&nbsp;double</code></div>
+<div class="col-first even-row-color"><code id="org.ironmaple.simulation.gamepieces.GamePieceOnField.MINIMUM_BOUNCING_VELOCITY">public&nbsp;static&nbsp;final&nbsp;double</code></div>
 <div class="col-second even-row-color"><code><a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html#MINIMUM_BOUNCING_VELOCITY">MINIMUM_BOUNCING_VELOCITY</a></code></div>
 <div class="col-last even-row-color"><code>0.2</code></div>
 </div>

--- a/docs/javadocs/index-all.html
+++ b/docs/javadocs/index-all.html
@@ -71,7 +71,7 @@ loadScripts(document, 'script');</script>
 </dd>
 <dt><a href="org/ironmaple/simulation/motorsims/SimulatedBattery.html#addElectricalAppliances(java.util.function.Supplier)" class="member-name-link">addElectricalAppliances(Supplier&lt;Current&gt;)</a> - Method in class org.ironmaple.simulation.motorsims.<a href="org/ironmaple/simulation/motorsims/SimulatedBattery.html" title="class in org.ironmaple.simulation.motorsims">SimulatedBattery</a></dt>
 <dd>&nbsp;</dd>
-<dt><a href="org/ironmaple/simulation/SimulatedArena.html#addGamePiece(org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation)" class="member-name-link">addGamePiece(GamePieceOnFieldSimulation)</a> - Method in class org.ironmaple.simulation.<a href="org/ironmaple/simulation/SimulatedArena.html" title="class in org.ironmaple.simulation">SimulatedArena</a></dt>
+<dt><a href="org/ironmaple/simulation/SimulatedArena.html#addGamePiece(org.ironmaple.simulation.gamepieces.GamePieceOnField)" class="member-name-link">addGamePiece(GamePieceOnFieldSimulation)</a> - Method in class org.ironmaple.simulation.<a href="org/ironmaple/simulation/SimulatedArena.html" title="class in org.ironmaple.simulation">SimulatedArena</a></dt>
 <dd>
 <div class="block">Registers a <a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces"><code>GamePieceOnFieldSimulation</code></a> to the Simulation.</div>
 </dd>
@@ -989,7 +989,7 @@ loadScripts(document, 'script');</script>
 <dd>&nbsp;</dd>
 <dt><a href="org/ironmaple/simulation/IntakeSimulation.html#register(org.ironmaple.simulation.SimulatedArena)" class="member-name-link">register(SimulatedArena)</a> - Method in class org.ironmaple.simulation.<a href="org/ironmaple/simulation/IntakeSimulation.html" title="class in org.ironmaple.simulation">IntakeSimulation</a></dt>
 <dd>&nbsp;</dd>
-<dt><a href="org/ironmaple/simulation/SimulatedArena.html#removeGamePiece(org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation)" class="member-name-link">removeGamePiece(GamePieceOnFieldSimulation)</a> - Method in class org.ironmaple.simulation.<a href="org/ironmaple/simulation/SimulatedArena.html" title="class in org.ironmaple.simulation">SimulatedArena</a></dt>
+<dt><a href="org/ironmaple/simulation/SimulatedArena.html#removeGamePiece(org.ironmaple.simulation.gamepieces.GamePieceOnField)" class="member-name-link">removeGamePiece(GamePieceOnFieldSimulation)</a> - Method in class org.ironmaple.simulation.<a href="org/ironmaple/simulation/SimulatedArena.html" title="class in org.ironmaple.simulation">SimulatedArena</a></dt>
 <dd>
 <div class="block">Removes a <a href="org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces"><code>GamePieceOnFieldSimulation</code></a> from the Simulation.</div>
 </dd>

--- a/docs/javadocs/org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html
+++ b/docs/javadocs/org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.html
@@ -75,7 +75,7 @@ loadScripts(document, 'script');</script>
 <div class="inheritance">org.dyn4j.collision.AbstractCollisionBody&lt;org.dyn4j.dynamics.BodyFixture&gt;
 <div class="inheritance">org.dyn4j.dynamics.AbstractPhysicsBody
 <div class="inheritance">org.dyn4j.dynamics.Body
-<div class="inheritance">org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation</div>
+<div class="inheritance">org.ironmaple.simulation.gamepieces.GamePieceOnField</div>
 </div>
 </div>
 </div>
@@ -100,7 +100,7 @@ loadScripts(document, 'script');</script>
 
  <p>For the simulation to actually run, every instance must be added to a
  <a href="../SimulatedArena.html" title="class in org.ironmaple.simulation"><code>SimulatedArena</code></a> through
- <a href="../SimulatedArena.html#addGamePiece(org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation)"><code>SimulatedArena.addGamePiece(GamePieceOnFieldSimulation)</code></a>.</div>
+ <a href="../SimulatedArena.html#addGamePiece(org.ironmaple.simulation.gam)"><code>SimulatedArena.addGamePiece(GamePieceOnFieldSimulation)</code></a>.</div>
 </section>
 <section class="summary">
 <ul class="summary-list">
@@ -254,7 +254,7 @@ loadScripts(document, 'script');</script>
 <dt>See Also:</dt>
 <dd>
 <ul class="see-list">
-<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.LINEAR_DAMPING">Constant Field Values</a></li>
+<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnField.LINEAR_DAMPING">Constant Field Values</a></li>
 </ul>
 </dd>
 </dl>
@@ -268,7 +268,7 @@ loadScripts(document, 'script');</script>
 <dt>See Also:</dt>
 <dd>
 <ul class="see-list">
-<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.ANGULAR_DAMPING">Constant Field Values</a></li>
+<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnField.ANGULAR_DAMPING">Constant Field Values</a></li>
 </ul>
 </dd>
 </dl>
@@ -282,7 +282,7 @@ loadScripts(document, 'script');</script>
 <dt>See Also:</dt>
 <dd>
 <ul class="see-list">
-<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.COEFFICIENT_OF_FRICTION">Constant Field Values</a></li>
+<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnField.COEFFICIENT_OF_FRICTION">Constant Field Values</a></li>
 </ul>
 </dd>
 </dl>
@@ -296,7 +296,7 @@ loadScripts(document, 'script');</script>
 <dt>See Also:</dt>
 <dd>
 <ul class="see-list">
-<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.COEFFICIENT_OF_RESTITUTION">Constant Field Values</a></li>
+<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnField.COEFFICIENT_OF_RESTITUTION">Constant Field Values</a></li>
 </ul>
 </dd>
 </dl>
@@ -310,7 +310,7 @@ loadScripts(document, 'script');</script>
 <dt>See Also:</dt>
 <dd>
 <ul class="see-list">
-<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation.MINIMUM_BOUNCING_VELOCITY">Constant Field Values</a></li>
+<li><a href="../../../../constant-values.html#org.ironmaple.simulation.gamepieces.GamePieceOnField.MINIMUM_BOUNCING_VELOCITY">Constant Field Values</a></li>
 </ul>
 </dd>
 </dl>

--- a/docs/javadocs/org/ironmaple/simulation/seasonspecific/crescendo2024/CrescendoNoteOnField.html
+++ b/docs/javadocs/org/ironmaple/simulation/seasonspecific/crescendo2024/CrescendoNoteOnField.html
@@ -71,7 +71,7 @@ loadScripts(document, 'script');</script>
 <div class="inheritance">org.dyn4j.collision.AbstractCollisionBody&lt;org.dyn4j.dynamics.BodyFixture&gt;
 <div class="inheritance">org.dyn4j.dynamics.AbstractPhysicsBody
 <div class="inheritance">org.dyn4j.dynamics.Body
-<div class="inheritance"><a href="../../gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces">org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation</a>
+<div class="inheritance"><a href="../../gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces">org.ironmaple.simulation.gamepieces.GamePieceOnField</a>
 <div class="inheritance">org.ironmaple.simulation.seasonspecific.crescendo2024.CrescendoNoteOnField</div>
 </div>
 </div>
@@ -109,7 +109,7 @@ loadScripts(document, 'script');</script>
 <div class="col-last even-row-color">&nbsp;</div>
 </div>
 <div class="inherited-list">
-<h3 id="fields-inherited-from-class-org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation">Fields inherited from class&nbsp;org.ironmaple.simulation.gamepieces.<a href="../../gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces">GamePieceOnFieldSimulation</a></h3>
+<h3 id="fields-inherited-from-class-org.ironmaple.simulation.gamepieces.GamePieceOnField">Fields inherited from class&nbsp;org.ironmaple.simulation.gamepieces.<a href="../../gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces">GamePieceOnFieldSimulation</a></h3>
 <code><a href="../../gamepieces/GamePieceOnFieldSimulation.html#ANGULAR_DAMPING">ANGULAR_DAMPING</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#COEFFICIENT_OF_FRICTION">COEFFICIENT_OF_FRICTION</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#COEFFICIENT_OF_RESTITUTION">COEFFICIENT_OF_RESTITUTION</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#LINEAR_DAMPING">LINEAR_DAMPING</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#MINIMUM_BOUNCING_VELOCITY">MINIMUM_BOUNCING_VELOCITY</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#type">type</a></code></div>
 <div class="inherited-list">
 <h3 id="fields-inherited-from-class-org.dyn4j.dynamics.AbstractPhysicsBody">Fields inherited from class&nbsp;org.dyn4j.dynamics.AbstractPhysicsBody</h3>
@@ -143,7 +143,7 @@ loadScripts(document, 'script');</script>
 <section class="method-summary" id="method-summary">
 <h2>Method Summary</h2>
 <div class="inherited-list">
-<h3 id="methods-inherited-from-class-org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation">Methods inherited from class&nbsp;org.ironmaple.simulation.gamepieces.<a href="../../gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces">GamePieceOnFieldSimulation</a></h3>
+<h3 id="methods-inherited-from-class-org.ironmaple.simulation.gamepieces.GamePieceOnField">Methods inherited from class&nbsp;org.ironmaple.simulation.gamepieces.<a href="../../gamepieces/GamePieceOnFieldSimulation.html" title="class in org.ironmaple.simulation.gamepieces">GamePieceOnFieldSimulation</a></h3>
 <code><a href="../../gamepieces/GamePieceOnFieldSimulation.html#getPose3d()">getPose3d</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#getPoseOnField()">getPoseOnField</a>, <a href="../../gamepieces/GamePieceOnFieldSimulation.html#setVelocity(edu.wpi.first.math.kinematics.ChassisSpeeds)">setVelocity</a></code></div>
 <div class="inherited-list">
 <h3 id="methods-inherited-from-class-org.dyn4j.dynamics.AbstractPhysicsBody">Methods inherited from class&nbsp;org.dyn4j.dynamics.AbstractPhysicsBody</h3>

--- a/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
@@ -18,7 +18,7 @@ import org.dyn4j.geometry.Vector2;
 import org.dyn4j.world.ContactCollisionData;
 import org.dyn4j.world.listener.ContactListener;
 import org.ironmaple.simulation.drivesims.AbstractDriveTrainSimulation;
-import org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation;
+import org.ironmaple.simulation.gamepieces.GamePieceOnField;
 
 /**
  *
@@ -34,15 +34,15 @@ import org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation;
  * <p>The intake can be turned on through {@link #startIntake()}, which causes it to extend, expanding the collision
  * space of the robot's chassis. When turned off via {@link #stopIntake()}, the intake retracts.
  *
- * <p>The intake can "collect" {@link GamePieceOnFieldSimulation} instances from the field, removing them and
+ * <p>The intake can "collect" {@link GamePieceOnField} instances from the field, removing them and
  * incrementing the {@link #gamePiecesInIntakeCount}.
  *
  * <p>A game piece is collected if the following conditions are met:
  *
  * <ul>
- *   <li>1. The type of the game piece ({@link org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation#type})
+ *   <li>1. The type of the game piece ({@link GamePieceOnField#type})
  *       matches {@link #targetedGamePieceType}.
- *   <li>2. The {@link org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation} is in contact with the intake
+ *   <li>2. The {@link GamePieceOnField} is in contact with the intake
  *       (and not other parts of the robot).
  *   <li>3. The intake is turned on via {@link #startIntake()}.
  *   <li>4. The number of game pieces in the intake ({@link #gamePiecesInIntakeCount}) is less than {@link #capacity}.
@@ -56,7 +56,7 @@ public class IntakeSimulation extends BodyFixture {
     private int gamePiecesInIntakeCount;
     private boolean intakeRunning;
 
-    private final Queue<GamePieceOnFieldSimulation> gamePiecesToRemove;
+    private final Queue<GamePieceOnField> gamePiecesToRemove;
     private final AbstractDriveTrainSimulation driveTrainSimulation;
     private final String targetedGamePieceType;
 
@@ -136,7 +136,7 @@ public class IntakeSimulation extends BodyFixture {
 
         return intakeRectangle;
     }
-    ;
+    
 
     /**
      *
@@ -178,7 +178,7 @@ public class IntakeSimulation extends BodyFixture {
      * <p>Extends the intake out from the chassis, making it part of the chassis's collision space.
      *
      * <p>Once activated, the intake is considered running and will listen for contact with
-     * {@link GamePieceOnFieldSimulation} instances, allowing it to collect game pieces.
+     * {@link GamePieceOnField} instances, allowing it to collect game pieces.
      */
     public void startIntake() {
         if (intakeRunning) return;
@@ -195,7 +195,7 @@ public class IntakeSimulation extends BodyFixture {
      * <p>Retracts the intake into the chassis, removing it from the chassis's collision space.
      *
      * <p>Once turned off, the intake will no longer listen for or respond to contacts with
-     * {@link GamePieceOnFieldSimulation} instances.
+     * {@link GamePieceOnField} instances.
      */
     public void stopIntake() {
         if (!intakeRunning) return;
@@ -236,9 +236,9 @@ public class IntakeSimulation extends BodyFixture {
      * <h2>The {@link ContactListener} for the Intake Simulation.</h2>
      *
      * <p>This class can be added to the simulation world to detect and manage contacts between the intake and
-     * {@link GamePieceOnFieldSimulation} instances of the type {@link #targetedGamePieceType}.
+     * {@link GamePieceOnField} instances of the type {@link #targetedGamePieceType}.
      *
-     * <p>If contact is detected and the intake is running, the {@link GamePieceOnFieldSimulation} will be marked for
+     * <p>If contact is detected and the intake is running, the {@link GamePieceOnField} will be marked for
      * removal from the field.
      */
     public final class GamePieceContactListener implements ContactListener<Body> {
@@ -250,15 +250,15 @@ public class IntakeSimulation extends BodyFixture {
             final CollisionBody<?> collisionBody1 = collision.getBody1(), collisionBody2 = collision.getBody2();
             final Fixture fixture1 = collision.getFixture1(), fixture2 = collision.getFixture2();
 
-            if (collisionBody1 instanceof GamePieceOnFieldSimulation gamePiece
+            if (collisionBody1 instanceof GamePieceOnField gamePiece
                     && Objects.equals(gamePiece.type, targetedGamePieceType)
                     && fixture2 == IntakeSimulation.this) flagGamePieceForRemoval(gamePiece);
-            else if (collisionBody2 instanceof GamePieceOnFieldSimulation gamePiece
+            else if (collisionBody2 instanceof GamePieceOnField gamePiece
                     && Objects.equals(gamePiece.type, targetedGamePieceType)
                     && fixture1 == IntakeSimulation.this) flagGamePieceForRemoval(gamePiece);
         }
 
-        private void flagGamePieceForRemoval(GamePieceOnFieldSimulation gamePiece) {
+        private void flagGamePieceForRemoval(GamePieceOnField gamePiece) {
             gamePiecesToRemove.add(gamePiece);
             gamePiecesInIntakeCount++;
         }
@@ -297,7 +297,7 @@ public class IntakeSimulation extends BodyFixture {
     /**
      *
      *
-     * <h2>Obtains the {@link GamePieceOnFieldSimulation} Instances to Be Removed from the Field.</h2>
+     * <h2>Obtains the {@link GamePieceOnField} Instances to Be Removed from the Field.</h2>
      *
      * <p>This method is called from {@link SimulatedArena#simulationPeriodic()} to retrieve game pieces that have been
      * marked for removal.
@@ -308,7 +308,7 @@ public class IntakeSimulation extends BodyFixture {
      *
      * @return a {@link Queue} of game pieces to be removed from the field
      */
-    public Queue<GamePieceOnFieldSimulation> getGamePiecesToRemove() {
+    public Queue<GamePieceOnField> getGamePiecesToRemove() {
         return gamePiecesToRemove;
     }
 

--- a/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
+++ b/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
@@ -357,7 +357,7 @@ public abstract class SimulatedArena {
      * @param type the type of game piece, as determined by the constructor of {@link GamePieceOnField}
      * @return a {@link List} of {@link Pose3d} objects representing the 3D positions of the game pieces
      */
-    public synchronized List<Pose3d> getGamePiecePoses(String type) {
+    public synchronized Pose3d[] getGamePiecePoses(String type) {
         final List<Pose3d> gamePiecesPoses = new ArrayList<>();
         for (GamePieceOnField gamePiece : gamePieces)
             if (Objects.equals(gamePiece.type, type)) gamePiecesPoses.add(gamePiece.getPose3d());
@@ -365,14 +365,14 @@ public abstract class SimulatedArena {
         for (GamePieceProjectile gamePiece : gamePieceProjectile)
             if (Objects.equals(gamePiece.gamePieceType, type)) gamePiecesPoses.add(gamePiece.getPose3d());
 
-        return gamePiecesPoses;
+        return gamePiecesPoses.toArray(new Pose3d[]{});
     }
     
     /**
      * <h2>Obtains the 3D Poses of all Crescendo notes.</h2>
      * @return a {@link List} of {@link Pose3d} objects representing the 3D positions of the notes
      */
-    public synchronized List<Pose3d> getNotePoses() {
+    public synchronized Pose3d[] getNotePoses() {
         return getGamePiecePoses("Note");
     }
     

--- a/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
+++ b/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
@@ -273,6 +273,7 @@ public abstract class SimulatedArena {
     /**
      * @deprecated use {@link GamePieceOnField} instead.
      */
+    @Deprecated(forRemoval = true)
     public synchronized void removeGamePiece(GamePieceOnFieldSimulation gamePiece) {}
 
     /**

--- a/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceOnField.java
+++ b/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceOnField.java
@@ -1,0 +1,153 @@
+package org.ironmaple.simulation.gamepieces;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import java.util.function.DoubleSupplier;
+import org.dyn4j.dynamics.Body;
+import org.dyn4j.dynamics.BodyFixture;
+import org.dyn4j.geometry.Convex;
+import org.dyn4j.geometry.MassType;
+import org.ironmaple.simulation.IntakeSimulation;
+import org.ironmaple.simulation.SimulatedArena;
+import org.ironmaple.utils.mathutils.GeometryConvertor;
+
+/**
+ *
+ *
+ * <h1>Simulates a Game Piece on the Field.</h1>
+ *
+ * <p>This class simulates a game piece on the field, which has a collision space and interacts with other objects.
+ *
+ * <p>Game pieces can be "grabbed" by an {@link IntakeSimulation}.
+ *
+ * <p>For the simulation to actually run, every instance must be added to a
+ * {@link org.ironmaple.simulation.SimulatedArena} through
+ * {@link SimulatedArena#addGamePiece(GamePieceOnField)}.
+ */
+public class GamePieceOnField extends Body {
+    public static final double LINEAR_DAMPING = 3.5,
+            ANGULAR_DAMPING = 5,
+            COEFFICIENT_OF_FRICTION = 0.8,
+            COEFFICIENT_OF_RESTITUTION = 0.3,
+            MINIMUM_BOUNCING_VELOCITY = 0.2;
+
+    /**
+     *
+     *
+     * <h2>Supplier of the Current Z-Pose (Height) of the Game Piece.</h2>
+     *
+     * <p>Normally, the height is fixed at half the thickness of the game piece to simulate it being "on the ground."
+     *
+     * <p>If the game piece is flying at a low height, the height is calculated using the law of free-fall.
+     */
+    private final DoubleSupplier zPositionSupplier;
+    /**
+     *
+     *
+     * <h2>The Type of the Game Piece.</h2>
+     *
+     * <p>Affects the result of {@link SimulatedArena#getGamePiecePoses(String)}.
+     */
+    public final String type;
+
+    /**
+     *
+     *
+     * <h2>Creates a Game Piece on the Field with Fixed Height.</h2>
+     *
+     * @param type the type of the game piece, affecting categorization within the arena
+     * @param shape the shape of the collision space for the game piece
+     * @param gamePieceHeight the height (thickness) of the game piece, in meters
+     * @param mass the mass of the game piece, in kilograms
+     * @param initialPosition the initial position of the game piece on the field
+     */
+    public GamePieceOnField(
+            String type, Convex shape, double gamePieceHeight, double mass, Translation2d initialPosition) {
+        this(type, shape, () -> gamePieceHeight / 2, mass, initialPosition, new Translation2d());
+    }
+
+    /**
+     *
+     *
+     * <h2>Creates a Game Piece on the Field with Custom Height Supplier and Initial Velocity.</h2>
+     *
+     * @param type the type of the game piece, affecting categorization within the arena
+     * @param shape the shape of the collision space for the game piece
+     * @param zPositionSupplier a supplier that provides the current Z-height of the game piece
+     * @param mass the mass of the game piece, in kilograms
+     * @param initialPosition the initial position of the game piece on the field
+     * @param initialVelocityMPS the initial velocity of the game piece, in meters per second
+     */
+    public GamePieceOnField(
+            String type,
+            Convex shape,
+            DoubleSupplier zPositionSupplier,
+            double mass,
+            Translation2d initialPosition,
+            Translation2d initialVelocityMPS) {
+        super();
+        this.type = type;
+        this.zPositionSupplier = zPositionSupplier;
+
+        BodyFixture bodyFixture = super.addFixture(shape);
+
+        bodyFixture.setFriction(COEFFICIENT_OF_FRICTION);
+        bodyFixture.setRestitution(COEFFICIENT_OF_RESTITUTION);
+        bodyFixture.setRestitutionVelocity(MINIMUM_BOUNCING_VELOCITY);
+
+        bodyFixture.setDensity(mass / shape.getArea());
+        super.setMass(MassType.NORMAL);
+
+        super.translate(GeometryConvertor.toDyn4jVector2(initialPosition));
+
+        super.setLinearDamping(LINEAR_DAMPING);
+        super.setAngularDamping(ANGULAR_DAMPING);
+        super.setBullet(true);
+
+        super.setLinearVelocity(GeometryConvertor.toDyn4jVector2(initialVelocityMPS));
+    }
+
+    /**
+     *
+     *
+     * <h2>Sets the world velocity of this game piece.</h2>
+     *
+     * @param chassisSpeedsWorldFrame the speeds of the game piece
+     */
+    public void setVelocity(ChassisSpeeds chassisSpeedsWorldFrame) {
+        super.setLinearVelocity(GeometryConvertor.toDyn4jLinearVelocity(chassisSpeedsWorldFrame));
+        super.setAngularVelocity(chassisSpeedsWorldFrame.omegaRadiansPerSecond);
+    }
+
+    /**
+     *
+     *
+     * <h2>Obtains the 2d position of the game piece</h2>
+     *
+     * @return the 2d position of the game piece
+     */
+    public Pose2d getPoseOnField() {
+        return GeometryConvertor.toWpilibPose2d(super.getTransform());
+    }
+
+    /**
+     *
+     *
+     * <h2>Obtains a 3d pose of the game piece.</h2>
+     *
+     * <p>The 3d position is calculated from both the {@link #getPoseOnField()} and {@link #zPositionSupplier}
+     *
+     * @return the 3d position of the game piece
+     */
+    public Pose3d getPose3d() {
+        final Pose2d pose2d = getPoseOnField();
+        return new Pose3d(
+                pose2d.getX(),
+                pose2d.getY(),
+                zPositionSupplier.getAsDouble(),
+                new Rotation3d(0, 0, pose2d.getRotation().getRadians()));
+    }
+}

--- a/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceOnFieldSimulation.java
@@ -1,153 +1,27 @@
 package org.ironmaple.simulation.gamepieces;
 
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import java.util.function.DoubleSupplier;
-import org.dyn4j.dynamics.Body;
-import org.dyn4j.dynamics.BodyFixture;
 import org.dyn4j.geometry.Convex;
-import org.dyn4j.geometry.MassType;
-import org.ironmaple.simulation.IntakeSimulation;
-import org.ironmaple.simulation.SimulatedArena;
-import org.ironmaple.utils.mathutils.GeometryConvertor;
 
-/**
- *
- *
- * <h1>Simulates a Game Piece on the Field.</h1>
- *
- * <p>This class simulates a game piece on the field, which has a collision space and interacts with other objects.
- *
- * <p>Game pieces can be "grabbed" by an {@link IntakeSimulation}.
- *
- * <p>For the simulation to actually run, every instance must be added to a
- * {@link org.ironmaple.simulation.SimulatedArena} through
- * {@link SimulatedArena#addGamePiece(GamePieceOnFieldSimulation)}.
- */
-public class GamePieceOnFieldSimulation extends Body {
-    public static final double LINEAR_DAMPING = 3.5,
-            ANGULAR_DAMPING = 5,
-            COEFFICIENT_OF_FRICTION = 0.8,
-            COEFFICIENT_OF_RESTITUTION = 0.3,
-            MINIMUM_BOUNCING_VELOCITY = 0.2;
+import java.util.function.DoubleSupplier;
 
-    /**
-     *
-     *
-     * <h2>Supplier of the Current Z-Pose (Height) of the Game Piece.</h2>
-     *
-     * <p>Normally, the height is fixed at half the thickness of the game piece to simulate it being "on the ground."
-     *
-     * <p>If the game piece is flying at a low height, the height is calculated using the law of free-fall.
-     */
-    private final DoubleSupplier zPositionSupplier;
-    /**
-     *
-     *
-     * <h2>The Type of the Game Piece.</h2>
-     *
-     * <p>Affects the result of {@link SimulatedArena#getGamePiecesByType(String)}.
-     */
-    public final String type;
-
-    /**
-     *
-     *
-     * <h2>Creates a Game Piece on the Field with Fixed Height.</h2>
-     *
-     * @param type the type of the game piece, affecting categorization within the arena
-     * @param shape the shape of the collision space for the game piece
-     * @param gamePieceHeight the height (thickness) of the game piece, in meters
-     * @param mass the mass of the game piece, in kilograms
-     * @param initialPosition the initial position of the game piece on the field
-     */
-    public GamePieceOnFieldSimulation(
-            String type, Convex shape, double gamePieceHeight, double mass, Translation2d initialPosition) {
-        this(type, shape, () -> gamePieceHeight / 2, mass, initialPosition, new Translation2d());
-    }
-
-    /**
-     *
-     *
-     * <h2>Creates a Game Piece on the Field with Custom Height Supplier and Initial Velocity.</h2>
-     *
-     * @param type the type of the game piece, affecting categorization within the arena
-     * @param shape the shape of the collision space for the game piece
-     * @param zPositionSupplier a supplier that provides the current Z-height of the game piece
-     * @param mass the mass of the game piece, in kilograms
-     * @param initialPosition the initial position of the game piece on the field
-     * @param initialVelocityMPS the initial velocity of the game piece, in meters per second
-     */
-    public GamePieceOnFieldSimulation(
-            String type,
-            Convex shape,
-            DoubleSupplier zPositionSupplier,
-            double mass,
-            Translation2d initialPosition,
-            Translation2d initialVelocityMPS) {
-        super();
-        this.type = type;
-        this.zPositionSupplier = zPositionSupplier;
-
-        BodyFixture bodyFixture = super.addFixture(shape);
-
-        bodyFixture.setFriction(COEFFICIENT_OF_FRICTION);
-        bodyFixture.setRestitution(COEFFICIENT_OF_RESTITUTION);
-        bodyFixture.setRestitutionVelocity(MINIMUM_BOUNCING_VELOCITY);
-
-        bodyFixture.setDensity(mass / shape.getArea());
-        super.setMass(MassType.NORMAL);
-
-        super.translate(GeometryConvertor.toDyn4jVector2(initialPosition));
-
-        super.setLinearDamping(LINEAR_DAMPING);
-        super.setAngularDamping(ANGULAR_DAMPING);
-        super.setBullet(true);
-
-        super.setLinearVelocity(GeometryConvertor.toDyn4jVector2(initialVelocityMPS));
-    }
-
-    /**
-     *
-     *
-     * <h2>Sets the world velocity of this game piece.</h2>
-     *
-     * @param chassisSpeedsWorldFrame the speeds of the game piece
-     */
-    public void setVelocity(ChassisSpeeds chassisSpeedsWorldFrame) {
-        super.setLinearVelocity(GeometryConvertor.toDyn4jLinearVelocity(chassisSpeedsWorldFrame));
-        super.setAngularVelocity(chassisSpeedsWorldFrame.omegaRadiansPerSecond);
-    }
-
-    /**
-     *
-     *
-     * <h2>Obtains the 2d position of the game piece</h2>
-     *
-     * @return the 2d position of the game piece
-     */
-    public Pose2d getPoseOnField() {
-        return GeometryConvertor.toWpilibPose2d(super.getTransform());
-    }
-
-    /**
-     *
-     *
-     * <h2>Obtains a 3d pose of the game piece.</h2>
-     *
-     * <p>The 3d position is calculated from both the {@link #getPoseOnField()} and {@link #zPositionSupplier}
-     *
-     * @return the 3d position of the game piece
-     */
-    public Pose3d getPose3d() {
-        final Pose2d pose2d = getPoseOnField();
-        return new Pose3d(
-                pose2d.getX(),
-                pose2d.getY(),
-                zPositionSupplier.getAsDouble(),
-                new Rotation3d(0, 0, pose2d.getRotation().getRadians()));
-    }
+public class GamePieceOnFieldSimulation {
+	/**
+	 * @deprecated Use {@link GamePieceOnField} instead.
+	 */
+	@Deprecated(forRemoval = true)
+	public GamePieceOnFieldSimulation(String type, Convex shape, double gamePieceHeight, double mass, Translation2d initialPosition) {}
+	
+	/**
+	 * @deprecated Use {@link GamePieceOnField} instead.
+	 */
+	@Deprecated(forRemoval = true)
+	public GamePieceOnFieldSimulation(
+		String type,
+		Convex shape,
+		DoubleSupplier zPositionSupplier,
+		double mass,
+		Translation2d initialPosition,
+		Translation2d initialVelocityMPS
+	){}
 }

--- a/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceProjectile.java
+++ b/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceProjectile.java
@@ -26,7 +26,7 @@ import org.ironmaple.utils.FieldMirroringUtils;
  * <h3>Additional Features:</h3>
  *
  * <ul>
- *   <li>Optionally, it can be configured to become a {@link GamePieceOnFieldSimulation} upon touching the ground.
+ *   <li>Optionally, it can be configured to become a {@link GamePieceOnField} upon touching the ground.
  *   <li>Optionally, it can be configured to have a "desired target." Upon hitting the target, it can be configured to
  *       run a callback.
  * </ul>
@@ -99,7 +99,7 @@ public class GamePieceProjectile {
      * <h2>Creates a Game Piece Projectile Ejected from a Shooter.</h2>
      *
      * @param gamePieceType the type of game piece, which will affect the
-     *     {@link SimulatedArena#getGamePiecesByType(String)}
+     *     {@link SimulatedArena#getGamePiecePoses(String)}
      * @param robotPosition the position of the robot (not the shooter) at the time of launching the game piece
      * @param shooterPositionOnRobot the translation from the shooter's position to the robot's center, in the robot's
      *     frame of reference
@@ -173,7 +173,7 @@ public class GamePieceProjectile {
      * <h2>Creates a Game Piece Projectile Ejected from a Shooter.</h2>
      *
      * @param gamePieceType the type of game piece, which will affect the
-     *     {@link SimulatedArena#getGamePiecesByType(String)}
+     *     {@link SimulatedArena#getGamePiecePoses(String)}
      * @param initialPosition the position of the game piece at the moment it is launched into the air
      * @param initialLaunchingVelocityMPS the horizontal component of the initial velocity in the X-Y plane, in meters
      *     per second (m/s)
@@ -375,14 +375,14 @@ public class GamePieceProjectile {
     /**
      *
      *
-     * <h2>Adds a {@link GamePieceOnFieldSimulation} to a {@link SimulatedArena} to Simulate the Game Piece After
+     * <h2>Adds a {@link GamePieceOnField} to a {@link SimulatedArena} to Simulate the Game Piece After
      * Touch-Ground.</h2>
      *
-     * <p>The added {@link GamePieceOnFieldSimulation} will have the initial velocity of the game piece projectile.
+     * <p>The added {@link GamePieceOnField} will have the initial velocity of the game piece projectile.
      *
      * <p>The game piece will start falling from mid-air until it touches the ground.
      *
-     * <p>The added {@link GamePieceOnFieldSimulation} will always have collision space on the field, even before
+     * <p>The added {@link GamePieceOnField} will always have collision space on the field, even before
      * touching the ground.
      *
      * @param simulatedArena the arena simulation to which the game piece will be added, usually obtained from
@@ -390,7 +390,7 @@ public class GamePieceProjectile {
      */
     public void addGamePieceAfterTouchGround(SimulatedArena simulatedArena) {
         if (!becomesGamePieceOnGroundAfterTouchGround) return;
-        simulatedArena.addGamePiece(new GamePieceOnFieldSimulation(
+        simulatedArena.addGamePiece(new GamePieceOnField(
                 gamePieceType,
                 shape,
                 () -> Math.max(
@@ -410,7 +410,7 @@ public class GamePieceProjectile {
      * {@link #withHitTargetCallBack(Runnable)}
      *
      * <p>2. If a game piece {@link #hasHitGround()}, remove it and create a corresponding
-     * {@link GamePieceOnFieldSimulation} using {@link #addGamePieceAfterTouchGround(SimulatedArena)}
+     * {@link GamePieceOnField} using {@link #addGamePieceAfterTouchGround(SimulatedArena)}
      *
      * <p>3. If a game piece {@link #hasGoneOutOfField()}, remove it.
      */
@@ -436,10 +436,10 @@ public class GamePieceProjectile {
     /**
      *
      *
-     * <h2>Configures the Game Piece Projectile to Automatically Become a {@link GamePieceOnFieldSimulation} Upon
+     * <h2>Configures the Game Piece Projectile to Automatically Become a {@link GamePieceOnField} Upon
      * Touching Ground.</h2>
      *
-     * <p>This method configures the game piece projectile to transform into a {@link GamePieceOnFieldSimulation} when
+     * <p>This method configures the game piece projectile to transform into a {@link GamePieceOnField} when
      * it touches the ground.
      *
      * @param shape the shape of the game piece's collision space
@@ -588,7 +588,7 @@ public class GamePieceProjectile {
      * landed.
      *
      * <p>When the game piece is below this height, it will either be deleted or, if configured, transformed into a
-     * {@link GamePieceOnFieldSimulation} using {@link #enableBecomesGamePieceOnFieldAfterTouchGround(Convex, double,
+     * {@link GamePieceOnField} using {@link #enableBecomesGamePieceOnFieldAfterTouchGround(Convex, double,
      * double)}.
      *
      * @param heightAsTouchGround the height (in meters) at which the projectile is considered to touch the ground

--- a/project/src/main/java/org/ironmaple/simulation/seasonspecific/crescendo2024/Arena2024Crescendo.java
+++ b/project/src/main/java/org/ironmaple/simulation/seasonspecific/crescendo2024/Arena2024Crescendo.java
@@ -8,7 +8,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import org.ironmaple.simulation.SimulatedArena;
-import org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation;
+import org.ironmaple.simulation.gamepieces.GamePieceOnField;
 
 public class Arena2024Crescendo extends SimulatedArena {
     /** the obstacles on the 2024 competition field */
@@ -95,7 +95,7 @@ public class Arena2024Crescendo extends SimulatedArena {
 
         final Translation2d sourcePosition = toCurrentAllianceTranslation(BLUE_SOURCE_POSITION);
         /* if there is any game-piece 0.5 meters within the human player station, we don't throw a new note */
-        for (GamePieceOnFieldSimulation gamePiece : super.gamePieces)
+        for (GamePieceOnField gamePiece : super.gamePieces)
             if (gamePiece instanceof CrescendoNoteOnField
                     && gamePiece.getPoseOnField().getTranslation().getDistance(sourcePosition) < 1) return;
 

--- a/project/src/main/java/org/ironmaple/simulation/seasonspecific/crescendo2024/CrescendoNoteOnField.java
+++ b/project/src/main/java/org/ironmaple/simulation/seasonspecific/crescendo2024/CrescendoNoteOnField.java
@@ -3,9 +3,9 @@ package org.ironmaple.simulation.seasonspecific.crescendo2024;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
 import org.dyn4j.geometry.Geometry;
-import org.ironmaple.simulation.gamepieces.GamePieceOnFieldSimulation;
+import org.ironmaple.simulation.gamepieces.GamePieceOnField;
 
-public class CrescendoNoteOnField extends GamePieceOnFieldSimulation {
+public class CrescendoNoteOnField extends GamePieceOnField {
     /* https://www.andymark.com/products/frc-2024-am-4999 */
     public static final double NOTE_HEIGHT = Units.inchesToMeters(2),
             NOTE_DIAMETER = Units.inchesToMeters(14),


### PR DESCRIPTION
1. Changed "getGamePiecesByType" to "getGamePiecePoses" which makes it a bit more descriptive
2. Added "getNotePoses" method to make mispelling the gamepiece type less common for notes(in 2025, we can add the respective methods for the new gamepieces)
3. Renamed "GamePieceOnFieldSimulation" to "GamePieceOnField" to make it more consistent with "GamePieceProjectile"
4. Change the return types of getGamePiecePoses/getNotePoses to arrays instead of lists to allow for easier logging(most logging frameworks unfortunately don't support list logging)
5. Updated the docs as well(currently, the docs demonstrate logging a List via Logger.recordOutput which doesn't work).