### PR TITLE
Fix battery sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 
 ### Elevating FRC Java Robot Simulations to the Next Level with Physics Engines
 
-## Why a physics engine
+## Why physics engine?
 A simulation engine is a powerful tool that provides realistic approximations of physical systems. With **maple-sim**, we integrate the open-source Java rigid-body dynamics engine, [dyn4j](https://github.com/dyn4j/dyn4j), capable of simulating 2D forces and collisions between rigid shapes. This integration transforms the scope of robot simulations by enabling realistic interactions between robots, field elements, and game pieces.
 
 ![physics engine illustration](./docs/media/physics%20engine.png)
+
+## What is maple-sim?
 
 Before **maple-sim**, most FRC robot simulations focused solely on the robot itself—its sensors, movements, and internal operations. 
 Now, through the power of physics simulation, **maple-sim** allows your robot to engage directly with its environment. 
@@ -26,18 +28,22 @@ With this advanced level of simulation, the possibilities are endless. You can:
 
 **And the best part? You can achieve all of this without needing a real robot on hand.**
 
-## Online Documentation
-[Online documentation is here](https://shenzhen-robotics-alliance.github.io/maple-sim/).
+## Getting Started
+
+Getting started with one of our [template projects](https://shenzhen-robotics-alliance.github.io/maple-sim/#getting-started-with-templates).
+
+Check the [online documentation](https://shenzhen-robotics-alliance.github.io/maple-sim/) and [Javadocs](https://shenzhen-robotics-alliance.github.io/maple-sim/javadocs/).
+
+Vendor URL:
+```
+https://shenzhen-robotics-alliance.github.io/maple-sim/vendordep/maple-sim.json
+```
+<br>
+
 > 🙏  Big thanks to [@GrahamSH-LLK](https://www.chiefdelphi.com/u/nstrike/summary) for all the help in setting up the online documentation.
+> 🙏  Big thanks to [@nstrike](https://www.chiefdelphi.com/u/nstrike/summary) for all the help in setting up the Java Docs and VendorDep publishing.
 
-
-## Java Docs
-[Official javadocs is here](https://shenzhen-robotics-alliance.github.io/maple-sim/javadocs/).
-> 🙏  Big thanks to [@nstrike](https://www.chiefdelphi.com/u/nstrike/summary) for all the help in setting up the Java Docs.
-
-
-
-## Bugs Developing and Contributing
+## Reporting Bugs, Developing and Contributing
 
 - If you've encountered a bug while using maple-sim in your robot code, please [submit an issue](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/issues/new/choose) and select the "Bug Report" option.  We review issues regularly and will respond as quickly as possible.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,21 +33,26 @@ For an in-depth description of the simulations, please refer to [Simulation Deta
 ## Getting Started With Templates
 
 ??? "AdvantageKit Users"
-    AdvantageKit provides Advanced Swerve Drive templates for teams using Akit and swerve. These templates have been modified to implement maple-sim, you can use them directly: 
-    - [AKitSparkSwerveTemplate-maple-sim](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/main/templates/AdvantageKit_SparkSwerveTemplate-maple-sim):  The AdvantageKit Swerve Template with REV SparkMax hardware, enhanced with maple-sim integration for improved chassis physics simulation.
-    - [AkitTalonSwerveTemplate-maple-sim](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/main/templates/AdvantageKit_TalonSwerveTemplate-maple-sim): The AdvantageKit Swerve Template with CTRE hardware, enhanced with maple-sim integration for improved chassis physics simulation.
-    - [AkitTalonSwerveTemplate_EnhancedPhoenixSimulation](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/dev/templates/AdvantageKit_TalonSwerveTemplate_EnhancedPhoenixSimulation): A further enhanced version of the TalonSwerveTemplate-maple-sim project, utilizing [Phoenix 6 simulation](https://v6.docs.ctr-electronics.com/en/latest/docs/api-reference/simulation/simulation-intro.html) to simulate CTRE motor controller closed-loops and the CAN bus. *(Note: This project is in the dev branch, and the work is still in progress.)*
+    AdvantageKit provides Advanced Swerve Drive templates for teams using Akit and swerve. These templates have been modified to implement maple-sim, you can use them directly:
+    <br> 
+    [AKitSparkSwerveTemplate-maple-sim](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/main/templates/AdvantageKit_SparkSwerveTemplate-maple-sim):  The AdvantageKit Swerve Template with REV SparkMax hardware, enhanced with maple-sim integration for improved chassis physics simulation.
+    <br>
+    [AkitTalonSwerveTemplate-maple-sim](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/main/templates/AdvantageKit_TalonSwerveTemplate-maple-sim): The AdvantageKit Swerve Template with CTRE hardware, enhanced with maple-sim integration for improved chassis physics simulation.
+    <br>
+    [AkitTalonSwerveTemplate_EnhancedPhoenixSimulation](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/dev/templates/AdvantageKit_TalonSwerveTemplate_EnhancedPhoenixSimulation): A further enhanced version of the TalonSwerveTemplate-maple-sim project, utilizing [Phoenix 6 simulation](https://v6.docs.ctr-electronics.com/en/latest/docs/api-reference/simulation/simulation-intro.html) to simulate CTRE motor controller closed-loops and the CAN bus. *(Note: This project is in the dev branch, and the work is still in progress.)*
 
 ??? "YAGSL Users"
     maple-sim is officially included in YAGSL for 2025!
-    - See [YAGSL-2025](https://github.com/BroncBotz3481/YAGSL-Example/releases/tag/2025.1.0): Official 2025-beta release of the amazing [Yet Another Generic Swerve Drive Library](https://www.chiefdelphi.com/t/yet-another-generic-swerve-library-yagsl-v1-release/450844), with maple-sim implemented for enhanced drivetrain simulation.
+    <br>
+    See [YAGSL - 2025 release](https://github.com/BroncBotz3481/YAGSL-Example/releases/tag/2025.1.0): Official 2025-beta release of the amazing [Yet Another Generic Swerve Drive Library](https://www.chiefdelphi.com/t/yet-another-generic-swerve-library-yagsl-v1-release/450844), with maple-sim implemented for enhanced drivetrain simulation.
 
 ??? "Base-Talon-Swerve Users"
-    - See [Base-Talon-Swerve with maple-sim](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/main/templates/BaseTalonSwerve-maple-sim): Base-Talon-Swerve, modified with advanced drivetrain simulation. This is an example implementation of the [Simplified Swerve Simulation](https://shenzhen-robotics-alliance.github.io/maple-sim/3.1_SWERVE_SIM_EZ_MODE.html).
+    See [Base-Talon-Swerve with maple-sim](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/main/templates/BaseTalonSwerve-maple-sim): Base-Talon-Swerve, modified with advanced drivetrain simulation. This is an example implementation of the [Simplified Swerve Simulation](https://shenzhen-robotics-alliance.github.io/maple-sim/3.1_SWERVE_SIM_EZ_MODE.html).
 
 ??? "Other Custom Code"
-    - [Maple-Swerve-Skeleton](https://github.com/Shenzhen-Robotics-Alliance/Maple-Swerve-Skeleton): Our custom swerve drive project based on the Advanced Swerve Drive Project, featuring drivetrain simulation, vision simulation, and convenient control features.
-    - [5516-2024-OffSeason-RobotCode](https://github.com/Shenzhen-Robotics-Alliance/Maple-Swerve-Skeleton/tree/main/example/5516-2024-OffSeason): Our 2024 off-season robot code, which implements a range of advanced simulations. This code can be run on a real robot and even played like a video game. Watch the [Videos](https://www.youtube.com/watch?v=5jr1L8xWpog&list=PLFS6A0KifAK1ycwlzIlvvFJkWNsQHVjSN)
+    [Maple-Swerve-Skeleton](https://github.com/Shenzhen-Robotics-Alliance/Maple-Swerve-Skeleton): Our custom swerve drive project based on the Advanced Swerve Drive Project, featuring drivetrain simulation, vision simulation, and convenient control features.
+    <br>
+    [5516-2024-OffSeason-RobotCode](https://github.com/Shenzhen-Robotics-Alliance/Maple-Swerve-Skeleton/tree/main/example/5516-2024-OffSeason): Our 2024 off-season robot code, which implements a range of advanced simulations. This code can be run on a real robot and even played like a video game. Watch the [Videos](https://www.youtube.com/watch?v=5jr1L8xWpog&list=PLFS6A0KifAK1ycwlzIlvvFJkWNsQHVjSN)
 
 ## Online Documentation
 

--- a/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
+++ b/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
@@ -307,7 +307,6 @@ public abstract class SimulatedArena {
         synchronized (SimulatedArena.class) {
             final long t0 = System.nanoTime();
             competitionPeriodic();
-            SimulatedBattery.flush();
             // move through a few sub-periods in each update
             for (int i = 0; i < SIMULATION_SUB_TICKS_IN_1_PERIOD; i++) simulationSubTick(i);
 
@@ -332,6 +331,7 @@ public abstract class SimulatedArena {
      * </ul>
      */
     private void simulationSubTick(int subTickNum) {
+        SimulatedBattery.flush();
         for (AbstractDriveTrainSimulation driveTrainSimulation : driveTrainSimulations)
             driveTrainSimulation.simulationSubTick();
 

--- a/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
+++ b/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
@@ -307,7 +307,7 @@ public abstract class SimulatedArena {
         synchronized (SimulatedArena.class) {
             final long t0 = System.nanoTime();
             competitionPeriodic();
-            SimulatedBattery.getInstance().flush();
+            SimulatedBattery.flush();
             // move through a few sub-periods in each update
             for (int i = 0; i < SIMULATION_SUB_TICKS_IN_1_PERIOD; i++) simulationSubTick(i);
 

--- a/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
+++ b/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
@@ -331,7 +331,7 @@ public abstract class SimulatedArena {
      * </ul>
      */
     private void simulationSubTick(int subTickNum) {
-        SimulatedBattery.flush();
+        SimulatedBattery.simulationSubTick();
         for (AbstractDriveTrainSimulation driveTrainSimulation : driveTrainSimulations)
             driveTrainSimulation.simulationSubTick();
 

--- a/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
@@ -205,9 +205,7 @@ public class SwerveModuleSimulation {
      * @return the current supplied to the drive motor
      */
     public Current getDriveMotorSupplyCurrent() {
-        return getDriveMotorStatorCurrent()
-                .times(driveMotorAppliedVoltage.div(
-                        SimulatedBattery.getBatteryVoltage()));
+        return getDriveMotorStatorCurrent().times(driveMotorAppliedVoltage.div(SimulatedBattery.getBatteryVoltage()));
     }
 
     /**
@@ -513,7 +511,10 @@ public class SwerveModuleSimulation {
         Torque driveWheelTorque = driveMotorConfigs.calculateTorque(driveMotorStatorCurrent);
 
         /* calculates the torque if you included losses from friction */
-        Torque driveWheelTorqueWithFriction = NewtonMeters.of(MathUtil.applyDeadband(driveWheelTorque.in(NewtonMeters), driveMotorConfigs.friction.in(NewtonMeters), Double.POSITIVE_INFINITY));
+        Torque driveWheelTorqueWithFriction = NewtonMeters.of(MathUtil.applyDeadband(
+                driveWheelTorque.in(NewtonMeters),
+                driveMotorConfigs.friction.in(NewtonMeters),
+                Double.POSITIVE_INFINITY));
         return driveWheelTorqueWithFriction.in(NewtonMeters);
     }
 

--- a/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
@@ -116,7 +116,7 @@ public class SwerveModuleSimulation {
         this.driveMotorConfigs = new SimMotorConfigs(
                 driveMotorModel, DRIVE_GEAR_RATIO, KilogramSquareMeters.zero(), driveFrictionVoltage);
 
-        SimulatedBattery.getInstance().addElectricalAppliances(this::getDriveMotorSupplyCurrent);
+        SimulatedBattery.addElectricalAppliances(this::getDriveMotorSupplyCurrent);
         this.steerMotorSim = new MapleMotorSim(
                 new SimMotorConfigs(steerMotorModel, steerGearRatio, steerRotationalInertia, steerFrictionVoltage));
 
@@ -207,7 +207,7 @@ public class SwerveModuleSimulation {
     public Current getDriveMotorSupplyCurrent() {
         return getDriveMotorStatorCurrent()
                 .times(driveMotorAppliedVoltage.div(
-                        SimulatedBattery.getInstance().getBatteryVoltage()));
+                        SimulatedBattery.getBatteryVoltage()));
     }
 
     /**
@@ -504,7 +504,7 @@ public class SwerveModuleSimulation {
                 getDriveEncoderUnGearedPosition(),
                 getDriveEncoderUnGearedSpeed());
 
-        driveMotorAppliedVoltage = Volts.of(MathUtil.clamp(driveMotorAppliedVoltage.in(Volts), -12, 12));
+        driveMotorAppliedVoltage = SimulatedBattery.clamp(driveMotorAppliedVoltage);
 
         driveMotorAppliedVoltage = Volts.of(
                 MathUtil.applyDeadband(driveMotorAppliedVoltage.in(Volts), DRIVE_FRICTION_VOLTAGE.in(Volts), 12));

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -15,29 +15,65 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+/**
+ *
+ *
+ * <h1>Simulates the main battery of the robot.</h1>
+ *
+ * <p>This class simulates the behavior of a robot's battery. Electrical appliances can be added to the battery to draw
+ * current. The battery voltage is affected by the current drawn from various appliances.
+ */
 public class SimulatedBattery {
-    private static final double BATTERY_NOMINAL_VOLTAGE = 13.5; // A fully charged battery should be 13.5 volts
+    // Nominal voltage for a fully charged battery (13.5 volts).
+    private static final double BATTERY_NOMINAL_VOLTAGE = 13.5;
 
+    // Filter to smooth the current readings.
     private static final LinearFilter currentFilter = LinearFilter.movingAverage(50);
+
     private static final List<Supplier<Current>> electricalAppliances = new ArrayList<>();
+
+    // The current battery voltage in volts.
     private static double batteryVoltageVolts = BATTERY_NOMINAL_VOLTAGE;
 
+    /**
+     *
+     *
+     * <h2>Adds a custom electrical appliance.</h2>
+     *
+     * <p>Connects the electrical appliance to the battery, allowing it to draw current from the battery.
+     *
+     * @param customElectricalAppliances The supplier for the current drawn by the appliance.
+     */
     public static void addElectricalAppliances(Supplier<Current> customElectricalAppliances) {
         electricalAppliances.add(customElectricalAppliances);
     }
 
+    /**
+     *
+     *
+     * <h2>Adds a motor to the list of electrical appliances.</h2>
+     *
+     * <p>The motor will draw current from the battery.
+     *
+     * @param mapleMotorSim The motor simulation object.
+     */
     public static void addMotor(MapleMotorSim mapleMotorSim) {
         electricalAppliances.add(mapleMotorSim::getSupplyCurrent);
     }
 
-    public static void flush() {
-        double totalCurrentAmps = electricalAppliances.stream()
-                        .mapToDouble(currentSupplier -> currentSupplier.get().in(Amps))
-                        .sum();
-
+    /**
+     *
+     *
+     * <h2>Updates the battery simulation.</h2>
+     *
+     * <p>Calculates the battery voltage based on the current drawn by all appliances.
+     *
+     * <p>The battery voltage is clamped to avoid going below the brownout voltage.
+     */
+    public static void simulationSubTick() {
+        double totalCurrentAmps = getTotalCurrentDrawn().in(Amps);
         totalCurrentAmps = currentFilter.calculate(totalCurrentAmps);
 
-        SmartDashboard.putNumber("BatterySim/TotalCurrentAmps", totalCurrentAmps);
         batteryVoltageVolts = BatterySim.calculateLoadedBatteryVoltage(BATTERY_NOMINAL_VOLTAGE, 0.02, totalCurrentAmps);
 
         if (Double.isNaN(batteryVoltageVolts)) {
@@ -53,17 +89,48 @@ public class SimulatedBattery {
         }
 
         RoboRioSim.setVInVoltage(batteryVoltageVolts);
+
+        SmartDashboard.putNumber("BatterySim/TotalCurrent (Amps)", totalCurrentAmps);
+        SmartDashboard.putNumber("BatterySim/BatteryVoltage (Volts)", batteryVoltageVolts);
     }
 
+    /**
+     *
+     *
+     * <h2>Obtains the voltage of the battery.</h2>
+     *
+     * @return The battery voltage as a {@link Voltage} object.
+     */
     public static Voltage getBatteryVoltage() {
         return Volts.of(batteryVoltageVolts);
     }
 
     /**
-     * Clamps the voltage to be a voltage between - battery voltage and + battery voltage.
      *
-     * @param voltage
-     * @return
+     *
+     * <h2>Obtains the total current drawn from the battery.</h2>
+     *
+     * <p>Iterates through all the appliances to obtain the total current used.
+     *
+     * @return The total current as a {@link Current} object.
+     */
+    public static Current getTotalCurrentDrawn() {
+        double totalCurrentAmps = electricalAppliances.stream()
+                .mapToDouble(currentSupplier -> currentSupplier.get().in(Amps))
+                .sum();
+        return Amps.of(totalCurrentAmps);
+    }
+
+    /**
+     *
+     *
+     * <h2>Clamps the voltage according to the supplied voltage and the battery's capabilities.</h2>
+     *
+     * <p>If the supplied voltage exceeds the battery's maximum voltage, it will be reduced to match the battery's
+     * voltage.
+     *
+     * @param voltage The voltage to be clamped.
+     * @return The clamped voltage as a {@link Voltage} object.
      */
     public static Voltage clamp(Voltage voltage) {
         return Volts.of(MathUtil.clamp(voltage.in(Volts), -batteryVoltageVolts, batteryVoltageVolts));

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -44,10 +44,10 @@ public class SimulatedBattery {
         batteryVoltageVolts = BatterySim.calculateDefaultBatteryLoadedVoltage(totalCurrentAmps);
         
         if (Double.isNaN(batteryVoltageVolts)) {
-            batteryVoltageVolts = RobotController.getBrownoutVoltage();
+            batteryVoltageVolts = 12.0;
             DriverStation.reportError(
                 "[MapleSim] Internal Library Error: Calculated battery voltage is invalid" +
-                    "(reverting to brownout voltage)",
+                    "(reverting to max robotcontroller voltage)",
                 false
             );
         } else {

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -36,7 +36,7 @@ public class SimulatedBattery {
         SmartDashboard.putNumber("BatterySim/TotalCurrentAmps", totalCurrentAmps);
         batteryVoltageVolts = BatterySim.calculateDefaultBatteryLoadedVoltage(totalCurrentAmps);
         
-        if (Double.isNaN(batteryVoltageVolts)) {
+        if (Double.isNaN(batteryVoltageVolts) || batteryVoltageVolts < 0) {
             batteryVoltageVolts = 12.0;
             DriverStation.reportError(
                 "[MapleSim] Internal Library Error: Calculated battery voltage is invalid" +

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -43,8 +43,6 @@ public class SimulatedBattery {
                     "(reverting to max robotcontroller voltage)",
                 false
             );
-        } else {
-            batteryVoltageVolts = MathUtil.clamp(RobotController.getBatteryVoltage(), 0, 12);
         }
         
         RoboRioSim.setVInVoltage(batteryVoltageVolts);

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -33,8 +33,7 @@ public class SimulatedBattery {
     public static void flush() {
         double totalCurrentAmps = electricalAppliances.stream()
                         .mapToDouble(currentSupplier -> currentSupplier.get().in(Amps))
-                        .sum()
-                / 2.0;
+                        .sum();
 
         totalCurrentAmps = currentFilter.calculate(totalCurrentAmps);
 

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -46,7 +46,8 @@ public class SimulatedBattery {
         if (Double.isNaN(batteryVoltageVolts)) {
             batteryVoltageVolts = RobotController.getBrownoutVoltage();
             DriverStation.reportError(
-                "[MapleSim] Internal Library Error: Calculated battery voltage is invalid",
+                "[MapleSim] Internal Library Error: Calculated battery voltage is invalid" +
+                    "(reverting to brownout voltage)",
                 false
             );
         } else {


### PR DESCRIPTION
Currently, MapleSim's battery sim can return NaN in fringe scenarios, causing RobotController.getBatteryVoltage() to return invalid values. This can be detrimental if PathPlanner's SwerveSetpointGenerator is used(or other calls to RobotController.getBatteryVoltage are used in the code), as they rely on RobotController.getBatteryVoltage.

This commit gives two safeguard:
1. It halves the current of the battery sim
2. It handles NaN scenarios by printing an error msg and defaulting to 12 volts instead

Currently, i dont exactly know what causes this.