### PR TITLE
Intake Simulation Fix & API Improvement & Documents Update

### DIFF
--- a/docs/simulating-intake.md
+++ b/docs/simulating-intake.md
@@ -32,18 +32,56 @@ You need to create an instance of `IntakeSimulation` in your `IntakeIOSim`.
 public class IntakeIOSim {
     private final IntakeSimulation intakeSimulation;
     public IntakeIOSim(AbstractDriveTrainSimulation driveTrain) {
-        this.intakeSimulation = new IntakeSimulation(
-                "Note", // This intake can collect game pieces of type "Note"
-                driveTrain, // Specify the drivetrain to which this intake is attached
-                0.6, // Width of the intake
-                0.1, // The extension length of the intake beyond the robot's frame
-                // For under-bumper intakes, set this to 0.01
-                IntakeSimulation.IntakeSide.BACK, // The intake is mounted on the back side of the chassis
-                1 // The intake can hold up to 1 note
-        );
+        // Here, create the intake simulation with respect to the intake on your real robot
+        this.intakeSimulation = new IntakeSimulation(...);
     }
 }
 ```
+
+??? "In-The-Frame (ITF) Intakes"
+    ![](media/intakesim3.png){ width= "30%"}
+    ```Java
+    this.intakeSimulation = IntakeSimulation.InTheFrameIntake(
+            // Specify the type of game pieces that the intake can collect
+            "Note",
+            // Specify the drivetrain to which this intake is attached
+            driveTrainSimulation,
+            // Specify width of the intake
+            Meters.of(0.7),
+            // The intake is mounted on the back side of the chassis
+            IntakeSimulation.IntakeSide.BACK,
+            // The intake can hold up to 1 note
+            1);
+    ```
+??? "Over-The-Bumper (OTB) Intakes"
+    ![](media/intakesim2.png){width="30%"}
+    ```Java
+    this.intakeSimulation = IntakeSimulation.InTheFrameIntake(
+            // Specify the type of game pieces that the intake can collect
+            "Note",
+            // Specify the drivetrain to which this intake is attached
+            driveTrainSimulation,
+            // Width of the intake
+            Meters.of(0.7),
+            // The extension length of the intake beyond the robot's frame (when activated)
+            Meters.of(0.2),
+            // The intake is mounted on the back side of the chassis
+            IntakeSimulation.IntakeSide.BACK,
+            // The intake can hold up to 1 note
+            1);
+    ```
+??? "Custom Shape Intakes"
+    ```Java
+    this.intakeSimulation = new IntakeSimulation(
+            // Specify the type of game pieces that the intake can collect
+            "Note",
+            // Specify the drivetrain to which this intake is attached
+            driveTrainSimulation, 
+            // Our intake has a custom shape of a triangle (shape is specified in chassis frame-of-reference)
+            new Triangle(new Vector2(0, 0), new Vector2(0.2, 0), new Vector2(0, 0.2)),
+            // The intake can hold up to 1 note
+            1);
+    ```
 
 ---
 ## 2. Using intake simulation

--- a/docs/simulating-intake.md
+++ b/docs/simulating-intake.md
@@ -38,50 +38,64 @@ public class IntakeIOSim {
 }
 ```
 
-??? "In-The-Frame (ITF) Intakes"
-    ![](media/intakesim3.png){ width= "30%"}
-    ```Java
-    this.intakeSimulation = IntakeSimulation.InTheFrameIntake(
-            // Specify the type of game pieces that the intake can collect
-            "Note",
-            // Specify the drivetrain to which this intake is attached
-            driveTrainSimulation,
-            // Specify width of the intake
-            Meters.of(0.7),
-            // The intake is mounted on the back side of the chassis
-            IntakeSimulation.IntakeSide.BACK,
-            // The intake can hold up to 1 note
-            1);
-    ```
-??? "Over-The-Bumper (OTB) Intakes"
-    ![](media/intakesim2.png){width="30%"}
-    ```Java
-    this.intakeSimulation = IntakeSimulation.InTheFrameIntake(
-            // Specify the type of game pieces that the intake can collect
-            "Note",
-            // Specify the drivetrain to which this intake is attached
-            driveTrainSimulation,
-            // Width of the intake
-            Meters.of(0.7),
-            // The extension length of the intake beyond the robot's frame (when activated)
-            Meters.of(0.2),
-            // The intake is mounted on the back side of the chassis
-            IntakeSimulation.IntakeSide.BACK,
-            // The intake can hold up to 1 note
-            1);
-    ```
-??? "Custom Shape Intakes"
-    ```Java
-    this.intakeSimulation = new IntakeSimulation(
-            // Specify the type of game pieces that the intake can collect
-            "Note",
-            // Specify the drivetrain to which this intake is attached
-            driveTrainSimulation, 
-            // Our intake has a custom shape of a triangle (shape is specified in chassis frame-of-reference)
-            new Triangle(new Vector2(0, 0), new Vector2(0.2, 0), new Vector2(0, 0.2)),
-            // The intake can hold up to 1 note
-            1);
-    ```
+=== "In-The-Frame (ITF) Intakes"
+    <div style="display: flex; align-items:center">
+        <div style="align-items: center; width: 29%">
+            <img src="../media/intakesim3.png" style="max-height: 100%; margin: auto;">
+        </div>
+        <div style="width: 70%; font-size:13px;">
+            ```Java
+            this.intakeSimulation = IntakeSimulation.InTheFrameIntake(
+                    // Specify the type of game pieces that the intake can collect
+                    "Note",
+                    // Specify the drivetrain to which this intake is attached
+                    driveTrainSimulation,
+                    // Specify width of the intake
+                    Meters.of(0.7),
+                    // The intake is mounted on the back side of the chassis
+                    IntakeSimulation.IntakeSide.BACK,
+                    // The intake can hold up to 1 note
+                    1);
+            ```
+        </div>
+    </div>
+=== "Over-The-Bumper (OTB) Intakes"
+    <div style="display: flex; align-items:center">
+        <div style="align-items: center; width: 29%"> 
+            <img src="../media/intakesim2.png" style="max-height: 100%; margin: auto;">
+        </div>
+        <div style="width: 70%; font-size:13px;">
+            ```Java
+            this.intakeSimulation = IntakeSimulation.OverTheBumperIntake(
+                    // Specify the type of game pieces that the intake can collect
+                    "Note",
+                    // Specify the drivetrain to which this intake is attached
+                    driveTrainSimulation,
+                    // Width of the intake
+                    Meters.of(0.7),
+                    // The extension length of the intake beyond the robot's frame (when activated)
+                    Meters.of(0.2),
+                    // The intake is mounted on the back side of the chassis
+                    IntakeSimulation.IntakeSide.BACK,
+                    // The intake can hold up to 1 note
+                    1);
+            ```
+        </div>
+    </div>
+=== "Custom Shape Intakes"
+    <div style="font-size:13px;">
+        ```Java
+        this.intakeSimulation = new IntakeSimulation(
+                // Specify the type of game pieces that the intake can collect
+                "Note",
+                // Specify the drivetrain to which this intake is attached
+                driveTrainSimulation, 
+                // Our intake has a custom shape of a triangle (shape is specified in chassis frame-of-reference)
+                new Triangle(new Vector2(0, 0), new Vector2(0.2, 0), new Vector2(0, 0.2)),
+                // The intake can hold up to 1 note
+                1);
+        ```
+    </div>
 
 ---
 ## 2. Using intake simulation

--- a/docs/swerve-sim-hardware-abstraction.md
+++ b/docs/swerve-sim-hardware-abstraction.md
@@ -170,8 +170,6 @@ When running the simulator, you can instantiate the above simulation IO implemen
 // creation the swerve simulation (please refer to previous documents)
 this.swerveDriveSimulation = new SwerveDriveSimulation(...);
 
-// 
-
 this.drive = new Drive(
         new GyroIOSim(this.swerveDriveSimulation.getGyroSimulation()),
         new ModuleIOSim(this.swerveDriveSimulation.getModules()[0]),

--- a/docs/swerve-simulation-overview.md
+++ b/docs/swerve-simulation-overview.md
@@ -60,13 +60,11 @@ SimulatedArena.getInstance().addDriveTrainSimulation(swerveDriveSimulation);
 ---
 ## 2. Manipulating the Simulated Swerve
 
-??? "Option 1: The simple approach"
+=== "Option 1: The simple approach"
     **See [Swerve Simulation: SimplifiedSwerveSimulation](./swerve-sim-easy.md)**<br>
     *This approach emphasizes ease of use while maintaining a reasonably accurate model of robot behavior. Although the physics simulation is realistic enough to accurately mimic your drivetrain, the code used to manipulate the simulated drivetrain is embedded into maple-sim for convenience. As a result, it may differ slightly from the code running on your real robot.*
-
-??? "Option 2: The professional approach"
+=== "Option 2: The professional approach"
     **See [Swerve Simulation: Hardware Abstraction](./swerve-sim-hardware-abstraction.md)**<br>
     *This approach to simulating swerve drive accurately mimics the behavior of your drivetrain code by running the exact same code used on the real robot directly on the simulated robot. While this ensures high fidelity in the simulation, it does require a significant amount of effort to set up properly.*
-
-??? "Option 3: Simulation with CTRE devices"
+=== "Option 3: Simulation with CTRE devices"
        Coming soon, [view progress](https://github.com/Shenzhen-Robotics-Alliance/maple-sim/tree/CTRE-simulation-support)

--- a/docs/using-the-simulated-arena.md
+++ b/docs/using-the-simulated-arena.md
@@ -77,11 +77,29 @@ SimulatedArena.getInstance().clearGamePieces();
 
 You can retrieve the positions of game pieces, including those on the ground and those launched into the air:
 
-```java
-// Get the positions of the notes (both on the field and in the air)
-List<Pose3d> notesPoses = SimulatedArena.getInstance().getGamePiecesByType("Note");
+=== "AdvantageKit" 
+      ```java 
+      void periodic() {
+            // Get the positions of the notes (both on the field and in the air)
+            Pose3d[] notesPoses = SimulatedArena.getInstance()
+                  .getGamePiecesArrayByType("Note");
+            // Publish to telemetry using AdvantageKit
+            Logger.recordOutput("FieldSimulation/NotesPositions", notesPoses);
+      }
+      ``` 
+=== "WPILib Networktables" 
+      ```java
+      StructArrayPublisher<Pose3d> notePoses = NetworkTableInstance.getDefault()
+            .getStructArrayTopic("MyPoseArray", Pose3d.struct)
+            .publish();
 
-// Publish to telemetry using AdvantageKit
-Logger.recordOutput("FieldSimulation/NotesPositions", notesPoses);
-```
+      void periodic() {
+            // Get the positions of the notes (both on the field and in the air)
+            Pose3d[] notesPoses = SimulatedArena.getInstance()
+                  .getGamePiecesArrayByType("Note");
+            notePoses.accept(SimulatedArena.getInstance()
+                  .getGamePiecesByType("Note")
+                  .toArray(Pose3d::new));
+      }
+      ```
 

--- a/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
@@ -71,19 +71,21 @@ public class IntakeSimulation extends BodyFixture {
      *
      * <h2>Creates an Intake Simulation that Tightly Attaches to One Side of the Chassis.</h2>
      *
+     * <p>This typically represents an In-The-Frame (ITF) Intake.
+     *
      * @param targetedGamePieceType the type of game pieces that this intake can collect
      * @param driveTrainSimulation the chassis to which this intake is attached
      * @param width the width of the intake
      * @param side the side of the chassis where the intake is attached
      * @param capacity the maximum number of game pieces that the intake can hold
      */
-    public IntakeSimulation(
+    public static IntakeSimulation InTheFrameIntake(
             String targetedGamePieceType,
             AbstractDriveTrainSimulation driveTrainSimulation,
             Distance width,
             IntakeSide side,
             int capacity) {
-        this(targetedGamePieceType, driveTrainSimulation, width, Meters.of(0.02), side, capacity);
+        return OverTheBumperIntake(targetedGamePieceType, driveTrainSimulation, width, Meters.of(0.02), side, capacity);
     }
 
     /**
@@ -91,21 +93,24 @@ public class IntakeSimulation extends BodyFixture {
      *
      * <h2>Creates an Intake Simulation that Extends Out of the Chassis Frame.</h2>
      *
+     * <p>This typically represents an Over-The-Bumper (OTB) Intake.
+     *
      * @param targetedGamePieceType the type of game pieces that this intake can collect
      * @param driveTrainSimulation the chassis to which this intake is attached
      * @param width the valid width of the intake
      * @param lengthExtended the length the intake extends out from the chassis when activated
      * @param side the side of the chassis where the intake is attached
      * @param capacity the maximum number of game pieces that the intake can hold
+     * @return a new instance of {@link IntakeSimulation} that extends over the bumper
      */
-    public IntakeSimulation(
+    public static IntakeSimulation OverTheBumperIntake(
             String targetedGamePieceType,
             AbstractDriveTrainSimulation driveTrainSimulation,
             Distance width,
             Distance lengthExtended,
             IntakeSide side,
             int capacity) {
-        this(
+        return new IntakeSimulation(
                 targetedGamePieceType,
                 driveTrainSimulation,
                 getIntakeRectangle(driveTrainSimulation, width.in(Meters), lengthExtended.in(Meters), side),
@@ -135,7 +140,6 @@ public class IntakeSimulation extends BodyFixture {
 
         return intakeRectangle;
     }
-    ;
 
     /**
      *
@@ -167,6 +171,8 @@ public class IntakeSimulation extends BodyFixture {
 
         this.intakeRunning = false;
         this.driveTrainSimulation = driveTrainSimulation;
+
+        register();
     }
 
     /**

--- a/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
+++ b/project/src/main/java/org/ironmaple/simulation/SimulatedArena.java
@@ -382,6 +382,17 @@ public abstract class SimulatedArena {
     /**
      *
      *
+     * <h2>Obtains the 3D Poses of a Specific Type of Game Piece as an array.</h2>
+     *
+     * @see #getGamePiecesByType(String)
+     */
+    public synchronized Pose3d[] getGamePiecesArrayByType(String type) {
+        return getGamePiecesByType(type).toArray(Pose3d[]::new);
+    }
+
+    /**
+     *
+     *
      * <h2>Resets the Field for Autonomous Mode.</h2>
      *
      * <p>This method clears all current game pieces from the field and places new game pieces in their starting

--- a/templates/BaseTalonSwerve-maple-sim/simgui.json
+++ b/templates/BaseTalonSwerve-maple-sim/simgui.json
@@ -2,6 +2,7 @@
   "NTProvider": {
     "types": {
       "/FMSInfo": "FMSInfo",
+      "/SmartDashboard/field": "Field2d",
       "/SmartDashboard/simulation field": "Field2d"
     }
   },

--- a/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/Robot.java
+++ b/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/Robot.java
@@ -48,11 +48,14 @@ public class Robot extends TimedRobot {
     @Override
     public void simulationPeriodic() {
         SimulatedArena.getInstance().simulationPeriodic();
+        Telemetry.getInstance().publishSimulationNotePoses();
     }
 
     /** This function is called once each time the robot enters Disabled mode. */
     @Override
-    public void disabledInit() {}
+    public void disabledInit() {
+        SimulatedArena.getInstance().resetFieldForAuto();
+    }
 
     @Override
     public void disabledPeriodic() {}

--- a/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/Telemetry.java
+++ b/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/Telemetry.java
@@ -1,0 +1,47 @@
+package frc.robot;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.StructArrayPublisher;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import org.ironmaple.simulation.SimulatedArena;
+
+public class Telemetry {
+    private static Telemetry instance = null;
+
+    public static Telemetry getInstance() {
+        if (instance == null) instance = new Telemetry();
+        return instance;
+    }
+
+    public final Field2d field2d;
+
+    StructArrayPublisher<Pose3d> notePoses = NetworkTableInstance.getDefault()
+            .getStructArrayTopic("MyPoseArray", Pose3d.struct)
+            .publish();
+
+    public Telemetry() {
+        this.field2d = new Field2d();
+        SmartDashboard.putData("field", field2d);
+    }
+
+    public Field2d getFieldWidget() {
+        return field2d;
+    }
+
+    public void feedSimulationRobotPose(Pose2d simulationRobotPose) {
+        field2d.setRobotPose(simulationRobotPose);
+    }
+
+    public void feedOdometryPose(Pose2d odometryPose) {
+        if (RobotBase.isReal()) field2d.setRobotPose(odometryPose);
+        else field2d.getObject("Odometry").setPose(odometryPose);
+    }
+
+    public void publishSimulationNotePoses() {
+        notePoses.accept(SimulatedArena.getInstance().getGamePiecesArrayByType("Note"));
+    }
+}

--- a/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/drive/MapleSimSwerve.java
+++ b/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/drive/MapleSimSwerve.java
@@ -13,16 +13,14 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.smartdashboard.Field2d;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
+import frc.robot.Telemetry;
 import org.ironmaple.simulation.SimulatedArena;
 import org.ironmaple.simulation.drivesims.*;
 import org.ironmaple.simulation.drivesims.configs.DriveTrainSimulationConfig;
 
 public class MapleSimSwerve implements SwerveDrive {
     private final SelfControlledSwerveDriveSimulation simulatedDrive;
-    private final Field2d field2d;
 
     public MapleSimSwerve() {
         final DriveTrainSimulationConfig config = DriveTrainSimulationConfig.Default()
@@ -46,9 +44,6 @@ public class MapleSimSwerve implements SwerveDrive {
 
         // register the drivetrain simulation to the simulation world
         SimulatedArena.getInstance().addDriveTrainSimulation(simulatedDrive.getDriveTrainSimulation());
-
-        field2d = new Field2d();
-        SmartDashboard.putData("simulation field", field2d);
     }
 
     @Override
@@ -112,7 +107,11 @@ public class MapleSimSwerve implements SwerveDrive {
     public void periodic() {
         simulatedDrive.periodic();
 
-        field2d.setRobotPose(simulatedDrive.getActualPoseInSimulationWorld());
-        field2d.getObject("odometry").setPose(getPose());
+        Telemetry.getInstance().feedSimulationRobotPose(simulatedDrive.getActualPoseInSimulationWorld());
+        Telemetry.getInstance().feedOdometryPose(getPose());
+    }
+
+    public AbstractDriveTrainSimulation getSimDrive() {
+        return simulatedDrive.getDriveTrainSimulation();
     }
 }

--- a/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/drive/TalonSwerve.java
+++ b/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/drive/TalonSwerve.java
@@ -13,17 +13,16 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.SwerveModule;
+import frc.robot.Telemetry;
 
 public class TalonSwerve extends SubsystemBase implements SwerveDrive {
     public SwerveDrivePoseEstimator swervePoseEstimator;
     public SwerveModule[] mSwerveMods;
     public Pigeon2 gyro;
-    private final Field2d field2d;
 
     public TalonSwerve() {
         gyro = new Pigeon2(Constants.Swerve.pigeonID);
@@ -39,9 +38,6 @@ public class TalonSwerve extends SubsystemBase implements SwerveDrive {
 
         swervePoseEstimator = new SwerveDrivePoseEstimator(
                 Constants.Swerve.swerveKinematics, getGyroYaw(), getModulePositions(), new Pose2d());
-
-        field2d = new Field2d();
-        SmartDashboard.putData("field", field2d);
     }
 
     @Override
@@ -122,7 +118,7 @@ public class TalonSwerve extends SubsystemBase implements SwerveDrive {
             SmartDashboard.putNumber("Mod " + mod.moduleNumber + " Velocity", mod.getState().speedMetersPerSecond);
         }
 
-        field2d.setRobotPose(getPose());
+        Telemetry.getInstance().feedOdometryPose(getPose());
     }
 
     @Override

--- a/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -1,0 +1,45 @@
+package frc.robot.subsystems.intake;
+
+import static edu.wpi.first.units.Units.Meters;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.FunctionalCommand;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import org.dyn4j.geometry.Rectangle;
+import org.dyn4j.geometry.Triangle;
+import org.dyn4j.geometry.Vector2;
+import org.ironmaple.simulation.IntakeSimulation;
+import org.ironmaple.simulation.drivesims.AbstractDriveTrainSimulation;
+
+public class Intake extends SubsystemBase {
+    private final IntakeSimulation intakeSimulation;
+
+    public Intake(AbstractDriveTrainSimulation driveTrainSimulation) {
+        this.intakeSimulation =
+                IntakeSimulation.InTheFrameIntake(
+                        "Note",
+                        driveTrainSimulation,
+                        Meters.of(0.7),
+                        IntakeSimulation.IntakeSide.BACK,
+                        1);
+        new IntakeSimulation(
+                "Note",
+                driveTrainSimulation,
+                new Triangle(new Vector2(0, 0), new Vector2(0.2, 0), new Vector2(0, 0.2)),
+                1);
+    }
+
+    public Command runIntake() {
+        return new FunctionalCommand(
+                intakeSimulation::startIntake,
+                () -> {},
+                (interrupted) -> intakeSimulation.stopIntake(),
+                () -> intakeSimulation.getGamePiecesAmount() > 0,
+                this);
+    }
+
+    public Command clearGamePiece() {
+        return Commands.runOnce(intakeSimulation::obtainGamePieceFromIntake, this);
+    }
+}

--- a/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/templates/BaseTalonSwerve-maple-sim/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -16,17 +16,11 @@ public class Intake extends SubsystemBase {
     private final IntakeSimulation intakeSimulation;
 
     public Intake(AbstractDriveTrainSimulation driveTrainSimulation) {
-        this.intakeSimulation =
-                IntakeSimulation.InTheFrameIntake(
-                        "Note",
-                        driveTrainSimulation,
-                        Meters.of(0.7),
-                        IntakeSimulation.IntakeSide.BACK,
-                        1);
-        new IntakeSimulation(
+        this.intakeSimulation = IntakeSimulation.InTheFrameIntake(
                 "Note",
                 driveTrainSimulation,
-                new Triangle(new Vector2(0, 0), new Vector2(0.2, 0), new Vector2(0, 0.2)),
+                Meters.of(0.7),
+                IntakeSimulation.IntakeSide.BACK,
                 1);
     }
 

--- a/templates/BaseTalonSwerve-maple-sim/vendordeps/maple-sim.json
+++ b/templates/BaseTalonSwerve-maple-sim/vendordeps/maple-sim.json
@@ -1,7 +1,7 @@
 {
     "fileName": "maple-sim.json",
     "name": "maplesim",
-    "version": "0.2.6prev",
+    "version": "0.2.7prev",
     "frcYear": "2025",
     "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "org.ironmaple",
             "artifactId": "maplesim-java",
-            "version": "0.2.6prev"
+            "version": "0.2.7prev"
         },
         {
             "groupId": "org.dyn4j",


### PR DESCRIPTION
- Fixed a bug in the intake simulation code. The intake was not automatically registered to the arena in the previous version. This fix should close issue #71.

- Refined the intake simulation API by refactoring the IntakeSimulation() constructors to IntakeSimulation.InTheFrameIntake() and IntakeSimulation.OverTheBumperIntake() for better clarity.

- Updated documentation on intake simulation, clearly outlining the differences between the types of intakes.

- Updated documentation on publishing the poses of gamepieces, providing guides for both Akit and WPILib NetworkTables users.