### PR TITLE
feat(IntakeSim): Add utility methods to access gamePiecesInIntakeCount

### DIFF
--- a/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
@@ -336,4 +336,12 @@ public class IntakeSimulation extends BodyFixture {
     public void register(SimulatedArena arena) {
         arena.addIntakeSimulation(this);
     }
+
+    public void addPiece() {
+        gamePiecesInIntakeCount++;
+    }
+
+    public void addPiece(int count) {
+        gamePiecesInIntakeCount = gamePiecesInIntakeCount + count;
+    }
 }

--- a/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
@@ -2,6 +2,7 @@ package org.ironmaple.simulation;
 
 import static edu.wpi.first.units.Units.Meters;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.units.measure.Distance;
 import java.util.ArrayDeque;
 import java.util.Objects;
@@ -236,6 +237,17 @@ public class IntakeSimulation extends BodyFixture {
         return true;
     }
 
+    public boolean addGamePieceToIntake() {
+        boolean toReturn = gamePiecesInIntakeCount < capacity;
+        if (toReturn)
+            gamePiecesInIntakeCount++;
+
+        return toReturn;
+    }
+    public int setGamePiecesCount(int gamePiecesInIntakeCount) {
+        return this.gamePiecesInIntakeCount = MathUtil.clamp(gamePiecesInIntakeCount, 0, capacity);
+    }
+
     /**
      *
      *
@@ -335,13 +347,5 @@ public class IntakeSimulation extends BodyFixture {
 
     public void register(SimulatedArena arena) {
         arena.addIntakeSimulation(this);
-    }
-
-    public void addPiece() {
-        gamePiecesInIntakeCount++;
-    }
-
-    public void addPiece(int count) {
-        gamePiecesInIntakeCount = gamePiecesInIntakeCount + count;
     }
 }

--- a/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/IntakeSimulation.java
@@ -225,11 +225,13 @@ public class IntakeSimulation extends BodyFixture {
     /**
      *
      *
-     * <h1>Removes 1 game piece from the intake.</h1>
+     * <h2>Removes 1 game piece from the intake.</h2>
      *
      * <p>Deducts the {@link #getGamePiecesAmount()}} by 1, if there is any remaining.
      *
      * <p>This is used to obtain a game piece from the intake and move it a feeder/shooter.
+     *
+     * @return if there is game piece(s) remaining, and therefore retrieved
      */
     public boolean obtainGamePieceFromIntake() {
         if (gamePiecesInIntakeCount < 1) return false;
@@ -237,6 +239,15 @@ public class IntakeSimulation extends BodyFixture {
         return true;
     }
 
+    /**
+     *
+     *
+     * <h2>Adds 1 game piece from the intake.</h2>
+     *
+     * <p>Increases the {@link #getGamePiecesAmount()}} by 1, if there is still space.
+     *
+     * @return if there is still space in the intake to perform this action
+     */
     public boolean addGamePieceToIntake() {
         boolean toReturn = gamePiecesInIntakeCount < capacity;
         if (toReturn)
@@ -244,6 +255,18 @@ public class IntakeSimulation extends BodyFixture {
 
         return toReturn;
     }
+
+    /**
+     *
+     *
+     * <h2>Sets the amount of game pieces in the intake.</h2>
+     *
+     * <p>Sets the {@link #getGamePiecesAmount()}} to a given amount.
+     *
+     * <p>Will make sure that the amount is non-negative and does not exceed the capacity</p>
+     *
+     * @return the actual (clamped) game piece count after performing this action
+     */
     public int setGamePiecesCount(int gamePiecesInIntakeCount) {
         return this.gamePiecesInIntakeCount = MathUtil.clamp(gamePiecesInIntakeCount, 0, capacity);
     }


### PR DESCRIPTION
This can be used to simulate features such as preloading at the start of auto. Previously, this would have to be done either by spawning a piece on the field such that it gets immediately picked up by the intake, or by using reflection to access the private field and increment it through code (which is hacky and unstable!).