### PR TITLE
Switch to wpilib motor sim

### DIFF
--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimMotorConfigs.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimMotorConfigs.java
@@ -65,6 +65,10 @@ public final class SimMotorConfigs {
         reverseHardwareLimit = Radians.of(-Double.POSITIVE_INFINITY);
     }
 
+    public Voltage getFrictionVoltage() {
+        return Volts.of(motor.getVoltage(friction.in(NewtonMeters), 0));
+    }
+
     /**
      *
      *


### PR DESCRIPTION
# Switch to wpilib motor sim

Use `DCMotorSim` to implement `MapleMotorSim` under the hood.
Fixes the underlying issue of https://github.com/Shenzhen-Robotics-Alliance/maple-sim/issues/86