### PR TITLE
Fix RebuiltFieldObstaclesMap: correct trench walls and remove magic numbers

### DIFF
--- a/docs/vendordep/maple-sim.json
+++ b/docs/vendordep/maple-sim.json
@@ -1,7 +1,7 @@
 {
     "fileName": "maple-sim.json",
     "name": "maplesim",
-    "version": "0.4.0-beta",
+    "version": "0.4.0-beta-obstacles-fix",
     "frcYear": "2026",
     "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
     "mavenUrls": [
@@ -13,7 +13,7 @@
         {
             "groupId": "org.ironmaple",
             "artifactId": "maplesim-java",
-            "version": "0.4.0-beta"
+            "version": "0.4.0-beta-obstacles-fix"
         },
         {
             "groupId": "org.dyn4j",

--- a/project/publish.gradle
+++ b/project/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '0.4.0-beta'
+def pubVersion = '0.4.0-beta-obstacles-fix'
 
 def outputsFolder = file("$buildDir/outputs")
 

--- a/project/src/main/java/org/ironmaple/simulation/seasonspecific/rebuilt2026/Arena2026Rebuilt.java
+++ b/project/src/main/java/org/ironmaple/simulation/seasonspecific/rebuilt2026/Arena2026Rebuilt.java
@@ -51,80 +51,121 @@ public class Arena2026Rebuilt extends SimulatedArena {
 
     /** the obstacles on the 2026 competition field */
     public static final class RebuiltFieldObstaclesMap extends FieldMap {
-        private static final double FIELD_WIDTH = 16.54;
+
+        private static final double FIELD_X_MIN = 0.00000;
+        private static final double FIELD_X_MAX = 16.54105;
+        private static final double FIELD_Y_MIN = 0.00000;
+        private static final double FIELD_Y_MAX = 8.06926;
+
+        private static final double HUB_X_LEN = 1.19380;
+        private static final double HUB_Y_LEN = 1.19380;
+        private static final double HUB_X = 4.625594;
+        private static final double HUB_Y = 4.03463;
+        private static final double HUB_RAMP_LENGTH = Inches.of(73.0).in(Meters);
+
+        private static final double UPRIGHT_X_LEN = Inches.of(3.5).in(Meters);
+        private static final double UPRIGHT_Y_LEN = Inches.of(1.5).in(Meters);
+        private static final double UPRIGHT_OFFSET_FROM_END_WALL = 1.06204;
+        private static final double UPRIGHT_OFFSET_FROM_SIDE_WALL = 3.31524;
+        private static final double UPRIGHT_Y_SPACING = Inches.of(33.75).in(Meters);
+
+        private static final double TRENCH_WALL_Y_LEN = Inches.of(12.0).in(Meters);
+        private static final double TRENCH_WALL_X_LEN = Inches.of(47.0).in(Meters);
+        private static final double TRENCH_WALL_OFFSET_FROM_END_WALL = 4.61769;
+        private static final double TRENCH_WALL_OFFSET_FROM_SIDE_WALL = 1.43113;
 
         public RebuiltFieldObstaclesMap(boolean AddRampCollider) {
-            super.addBorderLine(new Translation2d(0, 0), new Translation2d(0, 8.052));
+
+            // blue wall
+            addBorderLine(new Translation2d(FIELD_X_MIN, FIELD_Y_MIN), new Translation2d(FIELD_X_MIN, FIELD_Y_MAX));
 
             // red wall
-            super.addBorderLine(new Translation2d(16.540988, 0), new Translation2d(16.540988, 8.052));
+            addBorderLine(new Translation2d(FIELD_X_MAX, FIELD_Y_MIN), new Translation2d(FIELD_X_MAX, FIELD_Y_MAX));
 
-            // upper walls
-            super.addBorderLine(new Translation2d(16.540988, 8.052), new Translation2d(0, 8.052));
+            // scoring area walls
+            addBorderLine(new Translation2d(FIELD_X_MIN, FIELD_Y_MIN), new Translation2d(FIELD_X_MAX, FIELD_Y_MIN));
 
-            // lower walls
-            super.addBorderLine(new Translation2d(0, 0), new Translation2d(16.540988, 0));
+            // opposite side
+            addBorderLine(new Translation2d(FIELD_X_MIN, FIELD_Y_MAX), new Translation2d(FIELD_X_MAX, FIELD_Y_MAX));
 
-            // Trench Walls (47 inch height, 12 inch width)
-            double trenchWallDistX =
-                    Inches.of(120.0).in(Meters) + Inches.of(47.0 / 2).in(Meters);
+            // blue tower uprights
+            addRectangularObstacle(
+                    UPRIGHT_X_LEN,
+                    UPRIGHT_Y_LEN,
+                    new Pose2d(UPRIGHT_OFFSET_FROM_END_WALL, UPRIGHT_OFFSET_FROM_SIDE_WALL, new Rotation2d()));
+            addRectangularObstacle(
+                    UPRIGHT_X_LEN,
+                    UPRIGHT_Y_LEN,
+                    new Pose2d(
+                            UPRIGHT_OFFSET_FROM_END_WALL,
+                            UPRIGHT_OFFSET_FROM_SIDE_WALL + UPRIGHT_Y_SPACING,
+                            new Rotation2d()));
 
-            double trenchWallDistY = Inches.of(73.0).in(Meters)
-                    + Inches.of(47.0 / 2).in(Meters)
-                    + Inches.of(6).in(Meters);
+            // red tower uprights
+            addRectangularObstacle(
+                    UPRIGHT_X_LEN,
+                    UPRIGHT_Y_LEN,
+                    new Pose2d(
+                            FIELD_X_MAX - UPRIGHT_OFFSET_FROM_END_WALL,
+                            FIELD_Y_MAX - UPRIGHT_OFFSET_FROM_SIDE_WALL,
+                            new Rotation2d()));
+            addRectangularObstacle(
+                    UPRIGHT_X_LEN,
+                    UPRIGHT_Y_LEN,
+                    new Pose2d(
+                            FIELD_X_MAX - UPRIGHT_OFFSET_FROM_END_WALL,
+                            FIELD_Y_MAX - UPRIGHT_OFFSET_FROM_SIDE_WALL - UPRIGHT_Y_SPACING,
+                            new Rotation2d()));
 
-            super.addRectangularObstacle(
-                    Inches.of(53).in(Meters),
-                    Inches.of(12).in(Meters),
-                    new Pose2d(8.27 - trenchWallDistX, 4.035 - trenchWallDistY, Rotation2d.kZero));
-            super.addRectangularObstacle(
-                    Inches.of(53).in(Meters),
-                    Inches.of(12).in(Meters),
-                    new Pose2d(8.27 + trenchWallDistX, 4.035 - trenchWallDistY, Rotation2d.kZero));
-            super.addRectangularObstacle(
-                    Inches.of(53).in(Meters),
-                    Inches.of(12).in(Meters),
-                    new Pose2d(8.27 - trenchWallDistX, 4.035 + trenchWallDistY, Rotation2d.kZero));
-            super.addRectangularObstacle(
-                    Inches.of(53).in(Meters),
-                    Inches.of(12).in(Meters),
-                    new Pose2d(8.27 - trenchWallDistX, 4.035 - trenchWallDistY, Rotation2d.kZero));
+            // blue trench wall
+            addRectangularObstacle(
+                    TRENCH_WALL_X_LEN,
+                    TRENCH_WALL_Y_LEN,
+                    new Pose2d(TRENCH_WALL_OFFSET_FROM_END_WALL, TRENCH_WALL_OFFSET_FROM_SIDE_WALL, new Rotation2d()));
+            addRectangularObstacle(
+                    TRENCH_WALL_X_LEN,
+                    TRENCH_WALL_Y_LEN,
+                    new Pose2d(
+                            TRENCH_WALL_OFFSET_FROM_END_WALL,
+                            FIELD_Y_MAX - TRENCH_WALL_OFFSET_FROM_SIDE_WALL,
+                            new Rotation2d()));
 
-            // poles of the tower
-            super.addRectangularObstacle(
-                    Inches.of(2).in(Meters),
-                    Inches.of(47).in(Meters),
-                    new Pose2d(new Translation2d(Inches.of(42), Inches.of(159)), new Rotation2d()));
-
-            super.addRectangularObstacle(
-                    Inches.of(2).in(Meters),
-                    Inches.of(47).in(Meters),
-                    new Pose2d(new Translation2d(Inches.of(651 - 42), Inches.of(170)), new Rotation2d()));
+            // red trench wall
+            addRectangularObstacle(
+                    TRENCH_WALL_X_LEN,
+                    TRENCH_WALL_Y_LEN,
+                    new Pose2d(
+                            FIELD_X_MAX - TRENCH_WALL_OFFSET_FROM_END_WALL,
+                            TRENCH_WALL_OFFSET_FROM_SIDE_WALL,
+                            new Rotation2d()));
+            addRectangularObstacle(
+                    TRENCH_WALL_X_LEN,
+                    TRENCH_WALL_Y_LEN,
+                    new Pose2d(
+                            FIELD_X_MAX - TRENCH_WALL_OFFSET_FROM_END_WALL,
+                            FIELD_Y_MAX - TRENCH_WALL_OFFSET_FROM_SIDE_WALL,
+                            new Rotation2d()));
 
             // Colliders to describe the hub plus ramps
             if (AddRampCollider) {
-                super.addRectangularObstacle(
-                        Inches.of(47).in(Meters),
-                        Inches.of(217).in(Meters),
-                        new Pose2d(RebuiltHub.blueHubPose.toTranslation2d(), new Rotation2d()));
 
-                super.addRectangularObstacle(
-                        Inches.of(47).in(Meters),
-                        Inches.of(217).in(Meters),
-                        new Pose2d(RebuiltHub.redHubPose.toTranslation2d(), new Rotation2d()));
-            }
+                // blue hub + ramps
+                addRectangularObstacle(
+                        HUB_X_LEN, HUB_Y_LEN + 2.0 * HUB_RAMP_LENGTH, new Pose2d(HUB_X, HUB_Y, new Rotation2d()));
 
-            // Colliders to describe just the hub
-            else {
-                super.addRectangularObstacle(
-                        Inches.of(47).in(Meters),
-                        Inches.of(47).in(Meters),
-                        new Pose2d(RebuiltHub.blueHubPose.toTranslation2d(), new Rotation2d()));
+                // red hub + ramps
+                addRectangularObstacle(
+                        HUB_X_LEN,
+                        HUB_Y_LEN + 2.0 * HUB_RAMP_LENGTH,
+                        new Pose2d(FIELD_X_MAX - HUB_X, HUB_Y, new Rotation2d()));
 
-                super.addRectangularObstacle(
-                        Inches.of(47).in(Meters),
-                        Inches.of(47).in(Meters),
-                        new Pose2d(RebuiltHub.redHubPose.toTranslation2d(), new Rotation2d()));
+            } else {
+
+                // blue hub
+                addRectangularObstacle(HUB_X_LEN, HUB_Y_LEN, new Pose2d(HUB_X, HUB_Y, new Rotation2d()));
+
+                // red hub
+                addRectangularObstacle(HUB_X_LEN, HUB_Y_LEN, new Pose2d(FIELD_X_MAX - HUB_X, HUB_Y, new Rotation2d()));
             }
         }
     }


### PR DESCRIPTION
## Summary

- Refactored `RebuiltFieldObstaclesMap` to use named constants instead of magic numbers for better maintainability
- Fixed missing red-side top trench wall (was a duplicate of another wall in the original code)
- Corrected trench wall dimensions from 53" to 47" width
- Updated tower upright dimensions and positioning to match field specifications
- Added all 4 trench walls symmetrically placed on both sides of the field

## Key Changes

### Bug Fixes
1. **Missing trench wall**: The original code had a copy-paste bug where the 4th trench wall was a duplicate of the 1st, leaving one corner of the field without a trench wall
2. **Trench wall dimensions**: Corrected from 53"×12" to 47"×12" (X×Y)

### Code Quality
- Replaced all magic numbers with descriptive named constants (e.g., `TRENCH_WALL_X_LEN`, `UPRIGHT_OFFSET_FROM_END_WALL`)
- Added clear comments describing each obstacle group
- Field dimensions now use precise values matching the official field specifications

## Visual Comparison

### With Ramp Colliders (`AddRampCollider=true`)
<img width="2984" height="624" alt="obstacle_comparison_with_ramp" src="https://github.com/user-attachments/assets/14fa6282-dfa3-41ae-ae82-647d160be242" />

*Blue = This PR (current branch), Red = Main branch*

Key differences visible:
- Trench walls are now correctly sized (narrower in blue)
- All 4 trench walls present (main branch has duplicate/missing wall)
- Tower uprights are smaller and correctly oriented
- Hub positions slightly adjusted to match field specs

### Without Ramp Colliders (`AddRampCollider=false`)
<img width="2984" height="624" alt="obstacle_comparison_no_ramp" src="https://github.com/user-attachments/assets/bb337f46-3219-444f-8b61-39c4fe29fdea" />


*Blue = This PR (current branch), Red = Main branch*

Hub-only view showing the corrected hub positions.

## Numerical Comparison

| Obstacle | Current (This PR) | Main Branch |
|----------|-------------------|-------------|
| Trench Wall Width | 1.1938m (47") | 1.3462m (53") |
| Trench Wall Count | 4 (all unique) | 3 unique + 1 duplicate |
| Tower Upright Size | 0.089×0.038m (3.5"×1.5") | 0.051×1.194m (2"×47") |
| Blue Hub X | 4.6256m | 4.5974m |

## Test plan
- [x] Verify simulation runs without errors
- [x] Check robot collision behavior near trench walls
- [x] Verify hub collision boundaries match visual field layout


🤖 Generated with [Claude Code](https://claude.com/claude-code)