### PR TITLE
Pass shooter and chassis rotation separately

### DIFF
--- a/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceProjectile.java
+++ b/project/src/main/java/org/ironmaple/simulation/gamepieces/GamePieceProjectile.java
@@ -111,10 +111,11 @@ public class GamePieceProjectile implements GamePiece {
      *     frame of reference
      * @param chassisSpeedsFieldRelative the field-relative velocity of the robot chassis when launching the game piece,
      *     influencing the initial velocity of the game piece
-     * @param shooterFacing the direction in which the shooter is facing at launch
+     * @param chassisFacing the direction in which the robot chassis is facing at launch. Assumes the shooter is facing in the
+     *     same direction.
      * @param initialHeight the initial height of the game piece when launched, i.e., the height of the shooter from the
      *     ground
-     * @param launchingSpeed the speed at which the game piece is launch
+     * @param launchingSpeed the speed at which the game piece is launched
      * @param shooterAngle the pitch angle of the shooter when launching
      */
     public GamePieceProjectile(
@@ -122,16 +123,59 @@ public class GamePieceProjectile implements GamePiece {
             Translation2d robotPosition,
             Translation2d shooterPositionOnRobot,
             ChassisSpeeds chassisSpeedsFieldRelative,
+            Rotation2d chassisFacing,
+            Distance initialHeight,
+            LinearVelocity launchingSpeed,
+            Angle shooterAngle) {
+        this(
+                info,
+                robotPosition.plus(shooterPositionOnRobot.rotateBy(chassisFacing)),
+                calculateInitialProjectileVelocityMPS(
+                        shooterPositionOnRobot,
+                        chassisSpeedsFieldRelative,
+                        chassisFacing,
+                        chassisFacing,
+                        launchingSpeed.in(MetersPerSecond) * Math.cos(shooterAngle.in(Radians))),
+                initialHeight.in(Meters),
+                launchingSpeed.in(MetersPerSecond) * Math.sin(shooterAngle.in(Radians)),
+                new Rotation3d(0, -shooterAngle.in(Radians), chassisFacing.getRadians()));
+    }
+
+    /**
+     *
+     *
+     * <h2>Creates a Game Piece Projectile Ejected from a Shooter.</h2>
+     *
+     * @param info the info of the game piece
+     * @param robotPosition the position of the robot (not the shooter) at the time of launching the game piece
+     * @param shooterPositionOnRobot the translation from the shooter's position to the robot's center, in the robot's
+     *     frame of reference
+     * @param chassisSpeedsFieldRelative the field-relative velocity of the robot chassis when launching the game piece,
+     *     influencing the initial velocity of the game piece
+     * @param chassisFacing the direction in which the robot chassis is facing at launch
+     * @param shooterFacing the direction in which the shooter is facing at launch
+     * @param initialHeight the initial height of the game piece when launched, i.e., the height of the shooter from the
+     *     ground
+     * @param launchingSpeed the speed at which the game piece is launched
+     * @param shooterAngle the pitch angle of the shooter when launching
+     */
+    public GamePieceProjectile(
+            GamePieceOnFieldSimulation.GamePieceInfo info,
+            Translation2d robotPosition,
+            Translation2d shooterPositionOnRobot,
+            ChassisSpeeds chassisSpeedsFieldRelative,
+            Rotation2d chassisFacing,
             Rotation2d shooterFacing,
             Distance initialHeight,
             LinearVelocity launchingSpeed,
             Angle shooterAngle) {
         this(
                 info,
-                robotPosition.plus(shooterPositionOnRobot.rotateBy(shooterFacing)),
+                robotPosition.plus(shooterPositionOnRobot.rotateBy(chassisFacing)),
                 calculateInitialProjectileVelocityMPS(
                         shooterPositionOnRobot,
                         chassisSpeedsFieldRelative,
+                        chassisFacing,
                         shooterFacing,
                         launchingSpeed.in(MetersPerSecond) * Math.cos(shooterAngle.in(Radians))),
                 initialHeight.in(Meters),
@@ -151,6 +195,7 @@ public class GamePieceProjectile implements GamePiece {
      * @param chassisSpeeds the speeds of the chassis when the game piece is launched, including translational and
      *     rotational velocities
      * @param chassisFacing the direction the chassis is facing at the time of the launch
+     * @param shooterFacing the direction the shooter is facing at the time of the launch
      * @param groundSpeedMPS the ground component of the projectile's initial velocity, provided as a scalar in meters
      *     per second (m/s)
      * @return the calculated initial velocity of the projectile as a {@link Translation2d} in meters per second
@@ -159,6 +204,7 @@ public class GamePieceProjectile implements GamePiece {
             Translation2d shooterPositionOnRobot,
             ChassisSpeeds chassisSpeeds,
             Rotation2d chassisFacing,
+            Rotation2d shooterFacing,
             double groundSpeedMPS) {
         final Translation2d
                 chassisTranslationalVelocity =
@@ -170,7 +216,7 @@ public class GamePieceProjectile implements GamePiece {
                                 .times(chassisSpeeds.omegaRadiansPerSecond),
                 shooterGroundVelocity = chassisTranslationalVelocity.plus(shooterGroundVelocityDueToChassisRotation);
 
-        return shooterGroundVelocity.plus(new Translation2d(groundSpeedMPS, chassisFacing));
+        return shooterGroundVelocity.plus(new Translation2d(groundSpeedMPS, shooterFacing));
     }
 
     /**
@@ -656,3 +702,5 @@ public class GamePieceProjectile implements GamePiece {
         this.hitTargetCallBack = hitTargetCallBack;
     }
 }
+
+

--- a/project/src/main/java/org/ironmaple/simulation/seasonspecific/rebuilt2026/RebuiltFuelOnFly.java
+++ b/project/src/main/java/org/ironmaple/simulation/seasonspecific/rebuilt2026/RebuiltFuelOnFly.java
@@ -35,6 +35,7 @@ public class RebuiltFuelOnFly extends GamePieceProjectile {
      *     frame of reference
      * @param chassisSpeedsFieldRelative the field-relative velocity of the robot chassis when launching the FUEL,
      *     influencing the initial velocity of the FUEL
+     * @param chassisFacing the direction in which the robot chassis is facing at launch
      * @param shooterFacing the direction in which the shooter is facing at launch
      * @param initialHeight the initial height of the FUEL when launched, i.e., the height of the shooter from the
      *     ground
@@ -45,6 +46,7 @@ public class RebuiltFuelOnFly extends GamePieceProjectile {
             Translation2d robotPosition,
             Translation2d shooterPositionOnRobot,
             ChassisSpeeds chassisSpeedsFieldRelative,
+            Rotation2d chassisFacing,
             Rotation2d shooterFacing,
             Distance initialHeight,
             LinearVelocity launchingSpeed,
@@ -54,6 +56,7 @@ public class RebuiltFuelOnFly extends GamePieceProjectile {
                 robotPosition,
                 shooterPositionOnRobot,
                 chassisSpeedsFieldRelative,
+                chassisFacing,
                 shooterFacing,
                 initialHeight,
                 launchingSpeed,
@@ -61,5 +64,41 @@ public class RebuiltFuelOnFly extends GamePieceProjectile {
 
         super.withTouchGroundHeight(Inches.of(3).in(Meters));
         super.enableBecomesGamePieceOnFieldAfterTouchGround();
+    }
+
+    /**
+     *
+     *
+     * <h2>Creates a FUEL Projectile Ejected from a Shooter.</h2>
+     *
+     * @param robotPosition the position of the robot (not the shooter) at the time of launching the FUEL
+     * @param shooterPositionOnRobot the translation from the shooter's position to the robot's center, in the robot's
+     *     frame of reference
+     * @param chassisSpeedsFieldRelative the field-relative velocity of the robot chassis when launching the FUEL,
+     *     influencing the initial velocity of the FUEL
+     * @param chassisFacing the direction in which the robot chassis is facing at launch. Assumes the shooter is facing
+     *     the same direction.
+     * @param initialHeight the initial height of the FUEL when launched, i.e., the height of the shooter from the
+     *     ground
+     * @param launchingSpeed the speed at which the FUEL is launch
+     * @param shooterAngle the pitch angle of the shooter when launching
+     */
+    public RebuiltFuelOnFly(
+            Translation2d robotPosition,
+            Translation2d shooterPositionOnRobot,
+            ChassisSpeeds chassisSpeedsFieldRelative,
+            Rotation2d chassisFacing,
+            Distance initialHeight,
+            LinearVelocity launchingSpeed,
+            Angle shooterAngle) {
+        this(
+                robotPosition,
+                shooterPositionOnRobot,
+                chassisSpeedsFieldRelative,
+                chassisFacing,
+                chassisFacing,
+                initialHeight,
+                launchingSpeed,
+                shooterAngle);
     }
 }


### PR DESCRIPTION
Summary: The initial position of launched projectiles is not at the `shooterPositionOnRobot` if the shooter is not facing in the same direction as the chassis.

Description of the issue:
- The calculated initial position of the launched projectiles rotated the shooter location on the robot by the shooter facing angle instead of the robot facing angle.
- The constructor passed the parameter `shooterFacing` to the launch velocity calculation parameter called `chassisFacing` even though these are 2 different concepts.

This affects robots with turret shooters and robots with fixed shooters facing other directions than in front.

This PR separates the 2 parameters and use the appropriate one in each calculation. It keeps the existing constructors to avoid breaking existing projects but renames the parameter to `chassisFacing` since that is what it represents.

Code and video before the fix:
```
arena.addGamePieceProjectile(new RebuiltFuelOnFly(
    drivetrainSim.getSimulatedDriveTrainPose().getTranslation(),
    ShooterConstants.SHOOTER_POSITION_ON_ROBOT,
    drivetrainSim.getDriveTrainSimulatedChassisSpeedsFieldRelative(),
    drivetrainSim.getSimulatedDriveTrainPose().getRotation().plus(new Rotation2d(turret.getAngle())),
    ShooterConstants.SHOOTER_HEIGHT, 
    MetersPerSecond.of(shooter.getLeftVelocity().in(RotationsPerSecond) * ShooterConstants.FLYWHEEL_CIRCUMFERENCE.in(Meters) * ShooterConstants.SHOOTER_EFFICIENCY),
    hood.getAngle()
));
```

https://github.com/user-attachments/assets/0f509278-f651-4c74-8037-2634a2154b85

Code and video after the fix:
```
arena.addGamePieceProjectile(new RebuiltFuelOnFly(
    drivetrainSim.getSimulatedDriveTrainPose().getTranslation(),
    ShooterConstants.SHOOTER_POSITION_ON_ROBOT,
    drivetrainSim.getDriveTrainSimulatedChassisSpeedsFieldRelative(),
    drivetrainSim.getSimulatedDriveTrainPose().getRotation(),
    drivetrainSim.getSimulatedDriveTrainPose().getRotation().plus(new Rotation2d(turret.getAngle())),
    ShooterConstants.SHOOTER_HEIGHT, 
    MetersPerSecond.of(shooter.getLeftVelocity().in(RotationsPerSecond) * ShooterConstants.FLYWHEEL_CIRCUMFERENCE.in(Meters) * ShooterConstants.SHOOTER_EFFICIENCY),
    hood.getAngle()
));
```


https://github.com/user-attachments/assets/1939f6d3-cf7b-4fac-bc3f-4d00786ac877

